### PR TITLE
CD-187 components module check if enabled

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -20,6 +20,12 @@ function common_design_preprocess(&$variables, $hook) {
   // Add username.
   $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
   $variables['username'] = $user->getUsername();
+
+  //Check if Components module is enabled, to prevent page--demo.html.twig breaking due to twig errors.
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('components')){
+    $variables['componentsModule'] = TRUE;
+  }
 }
 
 /**
@@ -46,17 +52,6 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
 
   // This is for Drupal core search block.
   if ($form_id == 'search_block_form') {
-
-    //dpm($form); // Print out before change.
-    // The 'created' was my form element, yours would be which checkbox you wanted to change.
-    //$form['created']['#id'] = drupal_html_id('my-new-id');
-    //dpm($form); // Print out after change.
-
-    //$form['attributes']['id'][] = 'another-id ';
-
-    //dpm($form); // Print out after change.
-    //$form['#attributes']['id'][] = 'cd-search__form';
-    //dpm($form);
     $form['#attributes']['class'][] = 'cd-search__form';
     $form['#attributes']['aria-labelledby'][] = 'cd-search-btn';
     $form['#attributes']['data-cd-toggable'][] = 'Search';

--- a/templates/page--demo.html.twig
+++ b/templates/page--demo.html.twig
@@ -42,6 +42,7 @@
  * @see html.html.twig
  */
 #}
+
 <div class="cd-layout-container">
 
   {% block header %}
@@ -55,7 +56,9 @@
 
   {% block hero %}
     <div class="cd-layout-hero cd-container">
-      {% include '@cd-components/cd-hero/cd-hero.html.twig' %}
+      {% if componentsModule %}
+        {% include '@cd-components/cd-hero/cd-hero.html.twig' %}
+      {% endif %}
     </div>
   {% endblock %}
 
@@ -74,41 +77,45 @@
 
     <div class="cd-layout-content">
 
-      <h2>Components</h2>
+      {% if componentsModule %}
 
-      <h3>User interface</h3>
+        <h2>Components</h2>
 
-      {% include '@cd-components/cd-button/cd-button.html.twig' %}
+        <h3>User interface</h3>
 
-      {% include '@cd-components/cd-date/cd-date.html.twig' %}
+        {% include '@cd-components/cd-button/cd-button.html.twig' %}
 
-      {% include '@cd-components/cd-search/cd-search.html.twig' %}
+        {% include '@cd-components/cd-date/cd-date.html.twig' %}
 
-      {% include '@cd-components/cd-pagination/cd-pagination.html.twig' %}
+        {% include '@cd-components/cd-search/cd-search.html.twig' %}
 
-
-      <h3>Layouts</h3>
-
-      {% include '@cd-components/cd-grid/cd-grid.html.twig' %}
-
-      {% include '@cd-components/cd-image-grid/cd-image-grid.html.twig' %}
+        {% include '@cd-components/cd-pagination/cd-pagination.html.twig' %}
 
 
-      <h3>Content</h3>
+        <h3>Layouts</h3>
 
-      {% include '@cd-components/cd-article-teaser/cd-article-teaser.html.twig' %}
+        {% include '@cd-components/cd-grid/cd-grid.html.twig' %}
 
-      {% include '@cd-components/cd-bullet-list/cd-bullet-list.html.twig' %}
+        {% include '@cd-components/cd-image-grid/cd-image-grid.html.twig' %}
 
-      {% include '@cd-components/cd-list/cd-list.html.twig' %}
 
-      {% include '@cd-components/cd-teaser/cd-teaser.html.twig' %}
+        <h3>Content</h3>
 
-      {% include '@cd-components/cd-user-list/cd-user-list.html.twig' %}
+        {% include '@cd-components/cd-article-teaser/cd-article-teaser.html.twig' %}
 
-      {% include '@cd-components/cd-alert/cd-alert.html.twig' %}
+        {% include '@cd-components/cd-bullet-list/cd-bullet-list.html.twig' %}
 
-{#      {% include '@cd-components/cd-hero/cd-hero.html.twig' %}#}
+        {% include '@cd-components/cd-list/cd-list.html.twig' %}
+
+        {% include '@cd-components/cd-teaser/cd-teaser.html.twig' %}
+
+        {% include '@cd-components/cd-user-list/cd-user-list.html.twig' %}
+
+        {% include '@cd-components/cd-alert/cd-alert.html.twig' %}
+
+  {#      {% include '@cd-components/cd-hero/cd-hero.html.twig' %}#}
+
+      {% endif %}
 
       {{ page.content }}
 


### PR DESCRIPTION
To avoid twig errors (and site breaking) when /demo page is loaded, and components module is not installed.