### PR TITLE
CD-204 Expand selector to cd-dropdown elements only

### DIFF
--- a/js/cd-dropdown.js
+++ b/js/cd-dropdown.js
@@ -49,7 +49,7 @@
      * Collapse all toggable elements.
      */
     collapseAll: function (exceptions) {
-      var elements = document.querySelectorAll('[aria-expanded="true"]');
+      var elements = document.querySelectorAll('[data-cd-toggler][aria-expanded="true"]');
       exceptions = exceptions || [];
       var cdDropdown = this;
 


### PR DESCRIPTION
To prevent conflicts with other elements using the aria-expanded true and false for display, fixes #74