### PR TITLE
[CD-209] Fix CD header menus aria-labelledby and id attributes

### DIFF
--- a/templates/block/block--system-menu-block--account.html.twig
+++ b/templates/block/block--system-menu-block--account.html.twig
@@ -43,7 +43,7 @@
 
 {{ attach_library('common_design/cd-user-menu') }}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav{{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
+<nav role="navigation" {{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--system-menu-block--account.html.twig
+++ b/templates/block/block--system-menu-block--account.html.twig
@@ -43,7 +43,7 @@
 
 {{ attach_library('common_design/cd-user-menu') }}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+<nav{{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--system-menu-block--help.html.twig
+++ b/templates/block/block--system-menu-block--help.html.twig
@@ -43,7 +43,7 @@
 
 {{ attach_library('common_design/cd-user-menu') }}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav{{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
+<nav role="navigation" {{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--system-menu-block--help.html.twig
+++ b/templates/block/block--system-menu-block--help.html.twig
@@ -43,7 +43,7 @@
 
 {{ attach_library('common_design/cd-user-menu') }}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+<nav{{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--system-menu-block--main.html.twig
+++ b/templates/block/block--system-menu-block--main.html.twig
@@ -43,7 +43,7 @@
 %}
 
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav{{ attributes.setAttribute('aria-labelledby', heading_id).setAttribute('data-cd-toggable', 'Menu'|t).setAttribute('data-cd-component', 'cd-nav').setAttribute('data-cd-icon', 'arrow-down').addClass(classes)|without('role') }}>
+<nav role="navigation" {{ attributes.setAttribute('aria-labelledby', heading_id).setAttribute('data-cd-toggable', 'Menu'|t).setAttribute('data-cd-component', 'cd-nav').setAttribute('data-cd-icon', 'arrow-down').addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/templates/block/block--system-menu-block--main.html.twig
+++ b/templates/block/block--system-menu-block--main.html.twig
@@ -38,11 +38,12 @@
     'navigation',
     'menu--' ~ derivative_plugin_id|clean_class,
     'cd-nav',
+    'cd-site-header__nav',
   ]
 %}
 
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav id="cd-site-header__nav" role="navigation" {{ attributes.setAttribute('aria-labelledby', 'cd-nav-toggle').setAttribute('data-cd-toggable', 'Menu').setAttribute('data-cd-component', 'cd-nav').setAttribute('data-cd-icon', 'arrow-down').addClass(classes) }}>
+<nav{{ attributes.setAttribute('aria-labelledby', heading_id).setAttribute('data-cd-toggable', 'Menu'|t).setAttribute('data-cd-component', 'cd-nav').setAttribute('data-cd-icon', 'arrow-down').addClass(classes)|without('role') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/CD-209

This tries to consolidate the aria-labelledby and id attributes for the CD header menus (notably the main menu had 2 ids).

I also added translation for the 'Menu' button label (cd-toggable attribute on the main menu).

Initially I was thinking of removing the `navigation` role but as we still supports IE11, we need to keep it (See https://www.drupal.org/project/drupal/issues/2655794#comment-12161581).


