### PR TITLE
[CD-209] Ensure images have an alt tag

### DIFF
--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override of an image.
+ *
+ * Ensure there is an alt attribute.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the img tag.
+ * - style_name: (optional) The name of the image style applied.
+ *
+ * @see template_preprocess_image()
+ */
+#}
+{%
+set classes = [
+  style_name ? 'image-style-' ~ style_name|clean_class,
+]
+%}
+{% if not attributes.offsetExists('alt') %}
+<img{{ attributes.addClass(classes) }} alt=""/>
+{% else %}
+<img{{ attributes.addClass(classes) }}/>
+{% endif %}


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/CD-209

Context:  some images rendered via the `image.html.twig` template don't have an `alt` attribute. This can happen for example with media images migrated from Drupal 7 if they didn't have an alt value.

This overrides the `image.html.twig` template to check for the `alt` attribute and add an empty one if not present for better accessibility and validity.

Note: that is not an issue in the common design theme as other base themes have the same problem but the fix being easy, I think that would be a good addition to the common design base theme.

An alternative could be to implement a `hook_preprocess_image()` to add the `alt` attribute if not present but that's not necessarily better than the template.