### PR TITLE
[CD-212] Change the skip to content link target to be more in accordance with latest recommendations

### DIFF
--- a/templates/maintenance-page.html.twig
+++ b/templates/maintenance-page.html.twig
@@ -40,8 +40,8 @@
 
   </header>
 
-  <main role="main" class="cd-container">
-    <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+  {# Link to skip to the main content is in html.html.twig #}
+  <main role="main" id="main-content" class="cd-container">
 
     <div class="cd-layout-content">
     {% if title %}

--- a/templates/page--404.html.twig
+++ b/templates/page--404.html.twig
@@ -1,8 +1,8 @@
 {% embed 'page.html.twig' %}
 
   {% block main %}
-    <main role="main" class="cd-container">
-      <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" id="main-content" class="cd-container">
 
       <div class="cd-layout-content">
         <h1 class="page-title">404</h1>

--- a/templates/page--demo.html.twig
+++ b/templates/page--demo.html.twig
@@ -72,8 +72,8 @@
 
   {{ page.help }}
 
-  <main role="main" class="cd-container">
-    <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+  {# Link to skip to the main content is in html.html.twig #}
+  <main role="main" id="main-content" class="cd-container">
 
     <div class="cd-layout-content">
 

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -68,8 +68,8 @@
   {{ page.help }}
 
   {% block main %}
-    <main role="main" {{ attributes.addClass(layout_classes) }}>
-      <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+    {# Link to skip to the main content is in html.html.twig #}
+    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
 
       {% if page.sidebar_first %}
         {# We are using CSS pseudo class :empty to hide these aside elements if the region prints empty.


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/CD-212

Currently the target of the skip to content link is an `<a>` tag with the `main-content` id. This is an old method and not the recommended one, which is to add the id directly to the main sectioning element (`main` in our case): https://webaim.org/techniques/skipnav/

Drupal has an [open issue](https://www.drupal.org/project/drupal/issues/2784311) to patch core that's taking forever to be added because of the impact on bartik and other themes. That's however not an issue for us so we can change the `page.html.twig` template in the base common design theme.