### PR TITLE
make indentation for dependencies consistent

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -8,9 +8,9 @@ logo: 'img/logos/ocha-lockup-blue.svg'
 
 # Defines libraries group in which we can add css/js.
 libraries:
-- core/drupal
-- common_design/global-styling
-- common_design/cd-dropdown
+  - core/drupal
+  - common_design/global-styling
+  - common_design/cd-dropdown
 
 # Regions
 regions:

--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -7,19 +7,19 @@ cd-dropdown:
   js:
     js/cd-dropdown.js: {}
   dependencies:
-  - common_design/cd-polyfill
+    - common_design/cd-polyfill
 
 cd-menu:
   js:
     js/cd-menu.js: {}
   dependencies:
-  - common_design/cd-dropdown
+    - common_design/cd-dropdown
 
 cd-user-menu:
   js:
     js/cd-user-menu.js: {}
   dependencies:
-  - common_design/cd-dropdown
+    - common_design/cd-dropdown
 
 # CD components
 cd-alert:


### PR DESCRIPTION
Sorta fixes #98 because inconsistent indentation was confusing but all dependencies were loading because it seems indentation does not matter for children with hyphens

works:
```
cd-menu:
  js:
    js/cd-menu.js: {}
  dependencies:
    - common_design/cd-dropdown

```
also works:
```
cd-menu:
  js:
    js/cd-menu.js: {}
  dependencies:
  - common_design/cd-dropdown
```

**Drupal has indented children.**
https://www.drupal.org/docs/theming-drupal/adding-stylesheets-css-and-javascript-js-to-a-drupal-theme#s-declaring-dependencies
https://www.drupal.org/docs/8/theming-drupal-8/defining-a-theme-with-an-infoyml-file#dependencies