### PR TITLE
CD-issue 99 & 100 Error page templates

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -153,6 +153,18 @@ function common_design_preprocess_html(&$vars) {
     '#type' => 'inline_template',
     '#template' => '<span class="hidden">' . $icons . '</span>',
   );
+
+  // Check if current request is an exception to get error type
+  $status_code = \Drupal::requestStack()->getCurrentRequest()->attributes->get('exception');
+
+  // add body classes.
+  if ($status_code && $status_code->getStatusCode() == 404) {
+    $vars['attributes']['class'][] = 'path-error path-error--404';
+  }
+
+  if ($status_code && $status_code->getStatusCode() == 403) {
+    $vars['attributes']['class'][] = 'path-error path-error--403';
+  }
 }
 
 ///**

--- a/templates/page--404.html.twig
+++ b/templates/page--404.html.twig
@@ -5,8 +5,7 @@
     <main role="main" id="main-content" class="cd-container">
 
       <div class="cd-layout-content">
-        <h1 class="page-title">404</h1>
-        <p>{% trans %}Sorry, the page you are looking for cannot be found.{% endtrans %}</p>
+        {{ page.content }}
       </div>{# /.layout-content #}
 
     </main>


### PR DESCRIPTION
Replace text string with `page.content` region so generic error message appears on a 404 page *I assume the text string was there to provide a friendlier message and remains a nice option for specific implementations, but can be added to the sub theme instead.

Add class `page-error` and `page-error--404` to body class for 403 and 404 status codes, to facilitate styling of these pages.