### PR TITLE
CD-221 broken aria-labelledby and missing menuitem role

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -53,7 +53,7 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
   // This is for Drupal core search block.
   if ($form_id == 'search_block_form') {
     $form['#attributes']['class'][] = 'cd-search__form';
-    $form['#attributes']['aria-labelledby'][] = 'cd-search-btn';
+    $form['#attributes']['aria-labelledby'][] = 'cd-search-form';
     $form['#attributes']['data-cd-toggable'][] = 'Search';
     $form['#attributes']['data-cd-icon'][] = '';
     $form['#attributes']['data-cd-component'][] = 'cd-search';
@@ -73,7 +73,7 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
     // There are templates needed for this. Replace cd-search.html.twig
     // with cd-search--inline.html.twig in cd-site-header.html.twig.
 //    $form['#attributes']['class'][] = 'cd-search--inline__form';
-//    $form['#attributes']['aria-labelledby'][] = 'cd-search--inline__btn';
+//    $form['#attributes']['aria-labelledby'][] = 'cd-search-form--inline';
 //    $form['#attributes']['data-cd-toggable'][] = 'Search';
 //    $form['#attributes']['data-cd-icon'][] = '';
 //    $form['#attributes']['data-cd-component'][] = 'cd-search--inline';
@@ -99,7 +99,7 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
   // Replace $form['keys'] with the appropriate fulltext input eg. $form['search_api_fulltext'].
   if (in_array($form['#id'], $includeView)) {
     $form['#attributes']['class'][] = 'cd-search__form';
-    $form['#attributes']['aria-labelledby'][] = 'cd-search_btn';
+    $form['#attributes']['aria-labelledby'][] = 'cd-search-form';
     $form['#attributes']['data-cd-toggable'][] = 'Search';
     $form['#attributes']['data-cd-icon'][] = '';
     $form['#attributes']['data-cd-component'][] = 'cd-search';
@@ -120,7 +120,7 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
     // There are templates needed for this. Replace cd-search.html.twig
     // with cd-search--inline.html.twig in cd-site-header.html.twig.
 //      $form['#attributes']['class'][] = 'cd-search--inline__form';
-//      $form['#attributes']['aria-labelledby'][] = 'cd-search--inline__btn';
+//      $form['#attributes']['aria-labelledby'][] = 'cd-search-form--inline';
 //      $form['#attributes']['data-cd-toggable'][] = 'Search';
 //      $form['#attributes']['data-cd-icon'][] = '';
 //      $form['#attributes']['data-cd-component'][] = 'cd-search--inline';

--- a/components/cd-search/cd-search.html.twig
+++ b/components/cd-search/cd-search.html.twig
@@ -1,8 +1,8 @@
 {{ attach_library('common_design/cd-search') }}
 
 <div class="cd-search">
-  <div id="block-searchform" class="cd-search__form cd-dropdown" aria-labelledby="cd-search-btn" data-toggable="Search" data-hidden="true" data-component="cd-search" data-logo="search" role="search">
-    <h2 class="visually-hidden">Search Content</h2>
+  <div id="block-searchform" class="cd-search__form cd-dropdown" aria-labelledby="cd-search" data-toggable="Search" data-hidden="true" data-component="cd-search" data-logo="search" role="search">
+    <h2 class="visually-hidden" id="cd-search">Search Content</h2>
 
     <form action="/search/content" method="get">
 

--- a/components/cd-search/cd-search.html.twig
+++ b/components/cd-search/cd-search.html.twig
@@ -1,8 +1,8 @@
 {{ attach_library('common_design/cd-search') }}
 
 <div class="cd-search">
-  <div id="block-searchform" class="cd-search__form cd-dropdown" aria-labelledby="cd-search" data-toggable="Search" data-hidden="true" data-component="cd-search" data-logo="search" role="search">
-    <h2 class="visually-hidden" id="cd-search">Search Content</h2>
+  <div id="block-searchform" class="cd-search__form cd-dropdown" aria-labelledby="cd-search-form" data-toggable="Search" data-hidden="true" data-component="cd-search" data-logo="search" role="search">
+    <h2 id="cd-search-form" class="visually-hidden">Search Content</h2>
 
     <form action="/search/content" method="get">
 

--- a/templates/block/block--language-block.html.twig
+++ b/templates/block/block--language-block.html.twig
@@ -38,6 +38,13 @@
 
 <div{{ attributes.addClass(classes) }}>
   <div class="cd-language-switcher">
+    {# Label. If not displayed, we still provide it for screen readers. #}
+    {% if not configuration.label_display %}
+      {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+    {% endif %}
+    {{ title_prefix }}
+    <h2{{ title_attributes.setAttribute('id', 'cd-language-switcher') }}>{{ configuration.label }}</h2>
+    {{ title_suffix }}
 
     {% block content %}
       {{ content }}

--- a/templates/block/block--search-form-block.html.twig
+++ b/templates/block/block--search-form-block.html.twig
@@ -36,7 +36,7 @@
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if label %}
-    <h2{{ title_attributes.addClass('visually-hidden') }}>{{ label }}</h2>
+    <h2{{ title_attributes.addClass('visually-hidden').setAttribute('id', 'cd-search-form') }}>{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/templates/cd/cd-header/cd-ocha.html.twig
+++ b/templates/cd/cd-header/cd-ocha.html.twig
@@ -8,10 +8,10 @@
         <p class="cd-ocha-dropdown__heading">Related Platforms</p>
         <ul class="cd-ocha-dropdown__list">
           {% block related_platforms %}
-          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
           {% endblock %}
         </ul>
       </div>
@@ -19,10 +19,10 @@
         <p class="cd-ocha-dropdown__heading">Other OCHA Services</p>
         <ul class="cd-ocha-dropdown__list">
           {% block other_services_first %}
-          <li class="cd-ocha-dropdown__link"><a href="https://fts.unocha.org/">Financial Tracking Service</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://data.humdata.org/">Humanitarian Data Exchange</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://humanitarian.id/">Humanitarian ID</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://humanitarianresponse.info/">Humanitarian Response</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://fts.unocha.org/">Financial Tracking Service</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://data.humdata.org/">Humanitarian Data Exchange</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://humanitarian.id/">Humanitarian ID</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://humanitarianresponse.info/">Humanitarian Response</a></li>
           {% endblock %}
         </ul>
       </div>
@@ -30,10 +30,10 @@
         <p class="cd-ocha-dropdown__heading" aria-hidden="true">&nbsp;</p>
         <ul class="cd-ocha-dropdown__list">
           {% block other_services_second %}
-          <li class="cd-ocha-dropdown__link"><a href="https://interagencystandingcommittee.org">Inter-Agency Standing Committee</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://unocha.org/">OCHA website</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://reliefweb.int/">ReliefWeb</a></li>
-          <li class="cd-ocha-dropdown__link"><a href="https://vosocc.unocha.org/">Virtual OSOCC</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://interagencystandingcommittee.org">Inter-Agency Standing Committee</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://unocha.org/">OCHA website</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://reliefweb.int/">ReliefWeb</a></li>
+          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://vosocc.unocha.org/">Virtual OSOCC</a></li>
           {% endblock %}
         </ul>
       </div>

--- a/templates/cd/cd-header/cd-ocha.html.twig
+++ b/templates/cd/cd-header/cd-ocha.html.twig
@@ -2,16 +2,16 @@
 
   {# Dropdown toggle is created with javascript #}
 
-  <div class="cd-global-header__dropdown cd-ocha-dropdown cd-dropdown" role="menu" id="cd-ocha-dropdown" aria-label="OCHA Services" data-cd-toggable="OCHA Services" data-cd-hidden="true" data-cd-icon="arrow-down" data-cd-logo="ocha-logo" data-cd-component="cd-ocha">
+  <div class="cd-global-header__dropdown cd-ocha-dropdown cd-dropdown" id="cd-ocha-dropdown" aria-label="OCHA Services" data-cd-toggable="OCHA Services" data-cd-hidden="true" data-cd-icon="arrow-down" data-cd-logo="ocha-logo" data-cd-component="cd-ocha">
     <div class="cd-ocha-dropdown__inner">
       <div class="cd-ocha-dropdown__section">
         <p class="cd-ocha-dropdown__heading">Related Platforms</p>
         <ul class="cd-ocha-dropdown__list">
           {% block related_platforms %}
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://example.com">Customizable</a></li>
           {% endblock %}
         </ul>
       </div>
@@ -19,10 +19,10 @@
         <p class="cd-ocha-dropdown__heading">Other OCHA Services</p>
         <ul class="cd-ocha-dropdown__list">
           {% block other_services_first %}
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://fts.unocha.org/">Financial Tracking Service</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://data.humdata.org/">Humanitarian Data Exchange</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://humanitarian.id/">Humanitarian ID</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://humanitarianresponse.info/">Humanitarian Response</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://fts.unocha.org/">Financial Tracking Service</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://data.humdata.org/">Humanitarian Data Exchange</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://humanitarian.id/">Humanitarian ID</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://humanitarianresponse.info/">Humanitarian Response</a></li>
           {% endblock %}
         </ul>
       </div>
@@ -30,10 +30,10 @@
         <p class="cd-ocha-dropdown__heading" aria-hidden="true">&nbsp;</p>
         <ul class="cd-ocha-dropdown__list">
           {% block other_services_second %}
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://interagencystandingcommittee.org">Inter-Agency Standing Committee</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://unocha.org/">OCHA website</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://reliefweb.int/">ReliefWeb</a></li>
-          <li class="cd-ocha-dropdown__link" role="menuitem"><a href="https://vosocc.unocha.org/">Virtual OSOCC</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://interagencystandingcommittee.org">Inter-Agency Standing Committee</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://unocha.org/">OCHA website</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://reliefweb.int/">ReliefWeb</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://vosocc.unocha.org/">Virtual OSOCC</a></li>
           {% endblock %}
         </ul>
       </div>

--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -48,9 +48,9 @@
       <h2{{ heading.attributes }}>{{ heading.text }}</h2>
     {%- endif -%}
   {%- endif -%}
-  <ul{{ attributes.addClass(classes).setAttribute('id', 'cd-language').setAttribute('aria-labelledby', 'cd-language-toggle').setAttribute('role', 'menu').setAttribute('data-cd-toggable', "#{language}").setAttribute('data-cd-icon','arrow-down').setAttribute('data-cd-component', 'cd-language-switcher') }}>
+  <ul{{ attributes.addClass(classes).setAttribute('id', 'cd-language').setAttribute('aria-labelledby', 'cd-language-switcher').setAttribute('role', 'menu').setAttribute('data-cd-toggable', "#{language}").setAttribute('data-cd-icon','arrow-down').setAttribute('data-cd-component', 'cd-language-switcher') }}>
     {%- for item in links -%}
-      <li{{ item.attributes }}>
+      <li{{ item.attributes.setAttribute('role', 'menuitem') }}>
         {%- if item.link -%}
           {{ item.link }}
         {%- elseif item.text_attributes -%}

--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -48,9 +48,9 @@
       <h2{{ heading.attributes }}>{{ heading.text }}</h2>
     {%- endif -%}
   {%- endif -%}
-  <ul{{ attributes.addClass(classes).setAttribute('id', 'cd-language').setAttribute('aria-labelledby', 'cd-language-switcher').setAttribute('role', 'menu').setAttribute('data-cd-toggable', "#{language}").setAttribute('data-cd-icon','arrow-down').setAttribute('data-cd-component', 'cd-language-switcher') }}>
+  <ul{{ attributes.addClass(classes).setAttribute('id', 'cd-language').setAttribute('aria-labelledby', 'cd-language-switcher').setAttribute('data-cd-toggable', "#{language}").setAttribute('data-cd-icon','arrow-down').setAttribute('data-cd-component', 'cd-language-switcher') }}>
     {%- for item in links -%}
-      <li{{ item.attributes.setAttribute('role', 'menuitem') }}>
+      <li{{ item.attributes }}>
         {%- if item.link -%}
           {{ item.link }}
         {%- elseif item.text_attributes -%}


### PR DESCRIPTION
As per [CD-221](https://humanitarian.atlassian.net/browse/CD-221), I've correct the errors from WAVE tool.

For the search and language switcher, I added an ID to the block h2, and its value as aria-labelledby value.

For the OCHA Services and also language switcher block, I've added menuitem as role to the li elements. However I could use a second opinion on this. It's unclear to me whether the role=menu should be used, and if not, the menuitem role is not relevant.