### PR TITLE
CD-226: explicitly set line-height to normalize's default value

### DIFF
--- a/components/cd-button/cd-button.css
+++ b/components/cd-button/cd-button.css
@@ -49,6 +49,7 @@
   border: 2px solid transparent;
   padding: 0.5rem 1rem;
   font-size: 1rem;
+  line-height: 1.15;
   text-align: center;
   transition: background-color 0.6s ease-out,
   color 0.6s ease-out;


### PR DESCRIPTION
# CD-226 line-height `.cd-button`

While working on [HID-2169](https://humanitarian.atlassian.net/browse/HID-2169), I was using CD Buttons on both `<button>` and `<a>` elements which are horizontally aligned on a single row. The reason is because two buttons are submit/reset for a form, and the third was a hyperlink labeled "Cancel"

When I loaded the form, the Cancel button had more vertical space, leading the button to be taller. It ended up being a different `line-height` for links versus buttons. The PR further normalizes the value from `normalize.css` which sets buttons to `line-height: 1.15` and ensures that button-looking links also end up the same visual size.

### Before

<img width="605" alt="Screen Shot 2021-01-27 at 17 01 55" src="https://user-images.githubusercontent.com/254753/106018086-77374e80-60c1-11eb-8dbd-b731bd4e5c33.png">

### After

<img width="599" alt="Screen Shot 2021-01-27 at 17 02 16" src="https://user-images.githubusercontent.com/254753/106018116-7d2d2f80-60c1-11eb-950d-9e49d95b0c88.png">
