### PR TITLE
[CD-255] Fix menu attributes and add compatibility for GHO

### DIFF
--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -78,12 +78,13 @@
         {% if item.is_expanded and item.below %}
 
           {%
-            do attributes
-              .setAttribute('data-cd-toggable', title)
-              .setAttribute('data-cd-icon', 'arrow-down')
-              .setAttribute('data-cd-component', 'cd-user-menu')
-              .setAttribute('data-cd-replace', id)
-              .setAttribute('id', ('cd-user-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id)
+            set attributes =  create_attribute({
+              'data-cd-toggable': title,
+              'data-cd-icon': 'arrow-down',
+              'data-cd-component': 'cd-user-menu',
+              'data-cd-replace': id,
+              'id': ('cd-user-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id,
+            })
           %}
 
           {# Add the user icon for the first menu item of the root element. #}

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -76,12 +76,13 @@
         {% if item.is_expanded and item.below %}
 
           {%
-            do attributes
-              .setAttribute('data-cd-toggable', title)
-              .setAttribute('data-cd-icon', 'arrow-down')
-              .setAttribute('data-cd-component', 'cd-help-menu')
-              .setAttribute('data-cd-replace', id)
-              .setAttribute('id', ('cd-help-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id)
+            set attributes =  create_attribute({
+              'data-cd-toggable': title,
+              'data-cd-icon': 'arrow-down',
+              'data-cd-component': 'cd-help-menu',
+              'data-cd-replace': id,
+              'id': ('cd-help-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id,
+            })
           %}
 
           {# Add the help icon for the first menu item of the root element. #}

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -59,7 +59,7 @@
           be replaced with a button to show the child menu.
         #}
         {% if item.url %}
-        <a href="{{ item.url }}" id="{{ id }}">{{ title }}</a>
+        <a href="{{ item.url }}" id="{{ id }}"><span>{{ title }}</span></a>
         {% else %}
         <span id="{{ id }}">{{ title }}</span>
         {% endif %}
@@ -69,12 +69,13 @@
         {% if item.is_expanded and item.below %}
 
           {%
-            do attributes
-              .setAttribute('data-cd-toggable', item.title)
-              .setAttribute('data-cd-icon', 'arrow-down')
-              .setAttribute('data-cd-component', 'cd-main-menu')
-              .setAttribute('data-cd-replace', id)
-              .setAttribute('id', ('cd-main-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id)
+            set attributes =  create_attribute({
+              'data-cd-toggable': item.title,
+              'data-cd-icon': 'arrow-down',
+              'data-cd-component': 'cd-main-menu',
+              'data-cd-replace': id,
+              'id': ('cd-main-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id,
+            })
           %}
 
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}


### PR DESCRIPTION
Ticket: CD-255

This does 2 thinks: 

1. Reset the "attributes" variable before passing it to the nested menus.

This prevents attributes added to the top menu elements to be added to the nested menus which is the equivalent of what `stable` and `classy` themes for example do via a `if/else`:

```twig
    {% if menu_level == 0 %}
      <ul{{ attributes }}>
    {% else %}
      <ul>
    {% endif %}
```

2. Add `span` around the `title` when displaying links in the navigation menu. This is for compatibility for GHO and ease styling (ex: centering the title vertically).