### PR TITLE
CD-226 cd-button

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -12,7 +12,7 @@ Add a check if you've reviewed the component and it passes the Criteria.
 | cd-bleed            |                     |                     |
 | cd-block-title      |                     |                     |
 | cd-bullet-list      |                     |                     |
-| cd-button           |                     |                     |
+| cd-button           |       :x:           |                     |
 | cd-byline           |                     |                     |
 | cd-caption          |                     |                     |
 | cd-card             |                     |                     |

--- a/components/README.md
+++ b/components/README.md
@@ -12,7 +12,7 @@ Add a check if you've reviewed the component and it passes the Criteria.
 | cd-bleed            |                     |                     |
 | cd-block-title      |                     |                     |
 | cd-bullet-list      |                     |                     |
-| cd-button           |       :x:           |                     |
+| cd-button           | :heavy_check_mark:  |                     |
 | cd-byline           |                     |                     |
 | cd-caption          |                     |                     |
 | cd-card             |                     |                     |


### PR DESCRIPTION
Review the cd-button component

See https://feature.commondesign-unocha-org.ahconu.org/demo#cd-button for examples
This `cd-button` is also used in the OCHA Services menu.

See https://humanitarian.atlassian.net/browse/CD-249