### PR TITLE
[CD-263] Make theme compatible with Drupal 9 - V2

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -1,7 +1,7 @@
 name: OCHA Common Design
 type: theme
 description: OCHA Common Design drupal theme. Use as a base theme, and extend.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 # Defines the base theme
 base theme: classy
 logo: 'img/logos/ocha-lockup-blue.svg'

--- a/common_design.theme
+++ b/common_design.theme
@@ -234,7 +234,7 @@ function common_design_preprocess_menu(&$variables, $hook) {
   if ($hook == 'menu__account') {
     // Add username.
     $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-    $variables['username'] = $user->getUsername();
+    $variables['username'] = $user->getDisplayName();
     $variables['#cache']['contexts'][] = 'user';
   }
 }

--- a/common_design.theme
+++ b/common_design.theme
@@ -17,10 +17,6 @@ function common_design_preprocess(&$variables, $hook) {
   // Ensure the cache varies correctly.
   $variables['#cache']['contexts'][] = 'url.path.is_front';
 
-  // Add username.
-  $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-  $variables['username'] = $user->getUsername();
-
   //Check if Components module is enabled, to prevent page--demo.html.twig breaking due to twig errors.
   $moduleHandler = \Drupal::service('module_handler');
   if ($moduleHandler->moduleExists('components')){
@@ -222,11 +218,23 @@ function common_design_theme_suggestions_page_alter(array &$suggestions, array $
 //  ];
 //}
 
-///**
-// * Implements hook_block__language_block().
-// */
+/**
+ * Implements hook_block__language_block().
+ */
 function common_design_preprocess_block__language_block(&$vars) {
   // Current language available in template override.
   $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $vars['language'] = $language;
+}
+
+/**
+ * Implements hook_preprocess_menu().
+ */
+function common_design_preprocess_menu(&$variables, $hook) {
+  if ($hook == 'menu__account') {
+    // Add username.
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    $variables['username'] = $user->getUsername();
+    $variables['#cache']['contexts'][] = 'user';
+  }
 }


### PR DESCRIPTION
Ticket:  CD-263

This simply adds the requirement for compatibility with Drupal 9 to the v2.

It also replaces the [`User::getUsername()` deprecated function]( https://api.drupal.org/api/drupal/core%21modules%21user%21src%21Entity%21User.php/function/User%3A%3AgetUsername/8.2.x), after porting the user menu cache fix from https://github.com/UN-OCHA/common_design/pull/137

PR for the v1: https://github.com/UN-OCHA/common_design/pull/172