### PR TITLE
[CD-263] Make theme compatible with Drupal 9 - v1

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -1,7 +1,7 @@
 name: OCHA Common Design
 type: theme
 description: OCHA Common Design drupal theme. Use as a base theme, and extend.
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 # Defines the base theme
 base theme: classy
 logo: 'img/logos/ocha-lockup-blue.svg'

--- a/common_design.theme
+++ b/common_design.theme
@@ -235,7 +235,7 @@ function common_design_preprocess_menu(&$variables, $hook) {
   if ($hook == 'menu__account') {
     // Add username.
     $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-    $variables['username'] = $user->getUsername();
+    $variables['username'] = $user->getDisplayName();
     $variables['#cache']['contexts'][] = 'user';
   }
 }


### PR DESCRIPTION
Ticket: CD-263, CD-265

This simply adds the requirement for compatibility with Drupal 9 to the v1.

It also replaces the [`User::getUsername()` deprecated function]( https://api.drupal.org/api/drupal/core%21modules%21user%21src%21Entity%21User.php/function/User%3A%3AgetUsername/8.2.x).

PR for the v2: https://github.com/UN-OCHA/common_design/pull/171