### PR TITLE
CD-270 Bold field label

### DIFF
--- a/components/cd-form/cd-form.css
+++ b/components/cd-form/cd-form.css
@@ -30,6 +30,7 @@ textarea {
   }
 }
 
+.field__label,
 label {
   font-weight: 700;
 }


### PR DESCRIPTION
Noticed on POCAM
Drupal's `.field label` class is missing a style tho bold it. Missing after Classy was removed.