### PR TITLE
OPS-7412 subtheme inside the base theme issues

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -47,7 +47,9 @@ libraries-override:
         css/style.css: components/cd-select-a11y/cd-select-a11y.css
 
 # CD components
-component-libraries:
-  cd-components:
-    paths:
-      - components
+components:
+  namespaces:
+    cd-components: components
+    # Attempt to prevent missing template issues from subtheme being inside base theme directory.
+    # https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces
+    common_design_subtheme: commmon_design_subtheme/templates

--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -47,9 +47,7 @@ libraries-override:
         css/style.css: components/cd-select-a11y/cd-select-a11y.css
 
 # CD components
+# Requires Components module
 components:
   namespaces:
     cd-components: components
-    # Attempt to prevent missing template issues from subtheme being inside base theme directory.
-    # https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces
-    common_design_subtheme: commmon_design_subtheme/templates

--- a/common_design.theme
+++ b/common_design.theme
@@ -134,6 +134,15 @@ function common_design_theme_registry_alter(&$theme_registry) {
   if (isset($theme_registry['page_title'])) {
     $theme_registry['page_title']['variables']['title_attributes'] = [];
   }
+
+  // The theme discovery (drupal_find_theme_templates()) is too greedy and
+  // picks up the templates in `common_design/common_design_subtheme`. The code
+  // below reverts that behavior to use the `common_design` templates instead.
+  foreach ($theme_registry as $name => $theme_info) {
+    if (isset($theme_info['path']) && strpos($theme_info['path'], 'common_design/common_design_subtheme') !== FALSE) {
+      $theme_registry[$name]['path'] = str_replace('common_design/common_design_subtheme', 'common_design', $theme_info['path']);
+    }
+  }
 }
 
 /**

--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -5,7 +5,7 @@ A sub theme, extending [common_design](https://github.com/UN-OCHA/common_design)
 This can be used as a starting point for implementations. Add components, override and extend base theme as needed. Refer to [Drupal 8 Theming documentation](https://www.drupal.org/docs/8/theming) for more.
 
 Copy this directory to `/themes/custom/` and optionally rename the folder and associated theme files from
-`common_design_subtheme` to your theme name.
+`common_design_subtheme` to your theme name. Then rename the `common_design_subtheme.info.yml.example` to `common_design_subtheme.info.yml`.
 
 ### Path of the libraries
 If the subtheme name changes, the path of the global style sheet in `common_design_subtheme.info.yml` needs to reflect the new sub theme name.

--- a/common_design_subtheme/common_design_subtheme.info.yml.example
+++ b/common_design_subtheme/common_design_subtheme.info.yml.example
@@ -29,10 +29,8 @@ regions:
 #   common_design/cd-teaser:
 #     - common_design_subtheme/cd-teaser
 
-# CD components
-# Requires Components module
-components:
-  namespaces:
-# Attempt to prevent missing template issues from subtheme being inside base theme directory.
+# Custom namespace
 # https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces
-    common_design_subtheme: commmon_design_subtheme
+# Requires Components module
+# components:
+#   namespaces:

--- a/common_design_subtheme/common_design_subtheme.info.yml.example
+++ b/common_design_subtheme/common_design_subtheme.info.yml.example
@@ -31,7 +31,8 @@ regions:
 
 # CD components
 # Requires Components module
-# component-libraries:
-#   cd-components:
-#     paths:
-#       - components
+components:
+  namespaces:
+# Attempt to prevent missing template issues from subtheme being inside base theme directory.
+# https://www.drupal.org/docs/contributed-modules/components/understanding-twig-namespaces
+    common_design_subtheme: commmon_design_subtheme


### PR DESCRIPTION
Some experimenting with Twig namespace control of nested theme directories using the Components module for namespacing.
To prevent the `Template not defined` error when only the base theme is activated.
The base theme serves a few purposes. It demonstrates the component library and the Common Design header and footer (acting like a living styleguide), and ships the sub theme for implementations to use. In most cases, a sub theme will be activated and in the `themes/custom` directory so this issue will not be relevant.
This is for the exception that is the CD Demo site, which only shows the base theme.

```
Twig\Error\LoaderError: Template "@common_design_subtheme/cd/cd-header/cd-header.html.twig" is not defined in "themes/contrib/common_design/common_design_subtheme/templates/layout/page.html.twig" at line 4. in Twig\Loader\ChainLoader->getCacheKey() (line 142 of /srv/www/vendor/twig/twig/src/Loader/ChainLoader.php). 
```
https://www.drupal.org/project/drupal/issues/3071201

Note this also includes an update to how custom namespaces are defined, due to changes to the Components module API. Version 2 is required.