### PR TITLE
CD-288: explicitly upgrade font requests to HTTPS

### DIFF
--- a/common_design_subtheme/sass/cd/_cd-variables.scss
+++ b/common_design_subtheme/sass/cd/_cd-variables.scss
@@ -8,13 +8,13 @@
 
 // Multilingual
 // https://brand.unocha.org/d/xEPytAUjC3sH/visual-identity#/basics/fonts/multi-language-typefaces-1
-@import url("//fonts.googleapis.com/css2?family=Noto+Sans:wght@400%3B500%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400%3B500%3B700&display=swap");
 
 // Roboto
 // https://brand.unocha.org/d/xEPytAUjC3sH/visual-identity#/basics/fonts/advanced-users
-@import url("//fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&display=swap");
-@import url("//fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400%3B700&display=swap");
-@import url("//fonts.googleapis.com/css2?family=Roboto+Slab:wght@400%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400%3B700&display=swap");
 
 //——————————————————————————————————————————————————————————————————————————————
 // Colours

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "OCHA Common Design base theme for Drupal 8",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -64,12 +64,12 @@
 // @see http://www.google.com/fonts/earlyaccess
 @font-face {
   font-family: "Noto Kufi Arabic";
-  src: url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.eot");
+  src: url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.eot");
   src:
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.eot?#iefix") format("embedded-opentype"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.woff2") format("woff2"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.woff") format("woff"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.ttf") format("truetype");
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.eot?#iefix") format("embedded-opentype"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.woff2") format("woff2"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.woff") format("woff"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Regular.ttf") format("truetype");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -77,12 +77,12 @@
 
 @font-face {
   font-family: "Noto Kufi Arabic";
-  src: url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.eot");
+  src: url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.eot");
   src:
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.eot?#iefix") format("embedded-opentype"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.woff2") format("woff2"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.woff") format("woff"),
-    url("//fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.ttf") format("truetype");
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.eot?#iefix") format("embedded-opentype"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.woff2") format("woff2"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.woff") format("woff"),
+    url("https://fonts.gstatic.com/ea/notokufiarabic/v2/NotoKufiArabic-Bold.ttf") format("truetype");
   font-weight: 700;
   font-style: normal;
   font-display: swap;

--- a/sass/cd/_cd-variables.scss
+++ b/sass/cd/_cd-variables.scss
@@ -8,13 +8,13 @@
 
 // Multilingual
 // https://brand.unocha.org/d/xEPytAUjC3sH/visual-identity#/basics/fonts/multi-language-typefaces-1
-@import url("//fonts.googleapis.com/css2?family=Noto+Sans:wght@400%3B500%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400%3B500%3B700&display=swap");
 
 // Roboto
 // https://brand.unocha.org/d/xEPytAUjC3sH/visual-identity#/basics/fonts/advanced-users
-@import url("//fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&display=swap");
-@import url("//fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400%3B700&display=swap");
-@import url("//fonts.googleapis.com/css2?family=Roboto+Slab:wght@400%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400%3B700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400%3B700&display=swap");
 
 //——————————————————————————————————————————————————————————————————————————————
 // Colours


### PR DESCRIPTION
# CD-288

Upgrades fonts to always use HTTPS. See ticket for some links and references for why.