### PR TITLE
[OPS-7440] output baseUrl safely

### DIFF
--- a/_tests/_env/index.js
+++ b/_tests/_env/index.js
@@ -14,6 +14,9 @@ const environments = {
   },
 };
 
-console.log('⚠️ E2E testing', environments[process.env.NODE_ENV] && environments[process.env.NODE_ENV].baseUrl);
+const environmentExists = typeof environments[process.env.NODE_ENV] !== 'undefined';
+const env = environmentExists ? environments[process.env.NODE_ENV] : environments['local'];
 
-module.exports = process.env.NODE_ENV ? environments[process.env.NODE_ENV] : environments['local'];
+console.log('⚠️  E2E baseUrl: ', env.baseUrl);
+
+module.exports = env;

--- a/common_design_subtheme/_tests/_env/index.js
+++ b/common_design_subtheme/_tests/_env/index.js
@@ -14,6 +14,9 @@ const environments = {
   },
 };
 
-console.log('⚠️ E2E testing', environments[process.env.NODE_ENV].baseUrl);
+const environmentExists = typeof environments[process.env.NODE_ENV] !== 'undefined';
+const env = environmentExists ? environments[process.env.NODE_ENV] : environments['local'];
 
-module.exports = process.env.NODE_ENV ? environments[process.env.NODE_ENV] : environments['local'];
+console.log('⚠️  E2E baseUrl: ', env.baseUrl);
+
+module.exports = env;


### PR DESCRIPTION
I gave some bad, untested code suggestions in the other PR https://github.com/UN-OCHA/common_design/pull/221. This is fully tested. Set `NODE_ENV` to any value at all (including empty string) and this should work.