### PR TITLE
[CD-226] cd-grid review

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -23,7 +23,7 @@ Add a check if you've reviewed the component and it passes the Criteria.
 | cd-filter           |                     | :heavy_check_mark:  |
 | cd-flow             | :heavy_check_mark:  | :heavy_check_mark:  |
 | cd-form             | :heavy_check_mark:  | :heavy_check_mark:  |
-| cd-grid             |                     | :heavy_check_mark:  |
+| cd-grid             | :heavy_check_mark:  | :heavy_check_mark:  |
 | cd-hero             | :heavy_check_mark:  | :heavy_check_mark:  |
 | cd-image-grid       |                     | :heavy_check_mark:  |
 | cd-link-list        | :heavy_check_mark:  | :heavy_check_mark:  |

--- a/components/cd-grid/README.md
+++ b/components/cd-grid/README.md
@@ -1,15 +1,16 @@
 # Grid
 
 ## Purpose and Usage
-Basic grid layout with CSS grid and CSS flexbox layout based on @supports queries.
+Basic grid layout with CSS grid and CSS flexbox layout based on @supports
+queries.
 
 Default grid is 4 columns.
 
-The grid items are not width-restricted so with a 2 column grid, the items will span 50% of the available width.
+The grid items are not width-restricted so with a 2 column grid, the items will
+span 50% of the available width.
 
-@TODO Should cd-grid--grow should not be replaced by a class added to the grid element that should use the full width 
-rather than , if that should not be a class that could be applies to any element of the grid rather than just the last
-one. That would allow a header and footer span the full width inside a grid layout.
+@TODO Consider replacing cd-grid--grow with a class added to lone grid elements
+with css to make it use the full width:
 ```
       .cd-grid .cd-grid-item--grow {
         flex: 1 0 100%;
@@ -17,8 +18,8 @@ one. That would allow a header and footer span the full width inside a grid layo
         max-width: 100%;
         max-width: unset;
       }
-      
 ```
+This would allow a header and footer span the full width inside a grid layout.
 
 @TODO This might be dropped in favour of more robust grid system.
 
@@ -33,6 +34,6 @@ The selectors must be added to the parent div
 .cd-grid--4-col
 // Background colour on grid items.
 .cd-grid--background
-// Last item to span full width
+// Last item to span full width.
 .cd-grid--grow
 ```


### PR DESCRIPTION
I might have garbled the todo in the README - please check it makes sense!

The last-child approach seems to make more sense when there's just one item in the last row. Where there's more than one, you get an 'extra line':
![image](https://user-images.githubusercontent.com/67453/120332187-c7802080-c2ee-11eb-888b-2d54cf14e482.png)
Is that as planned?