### PR TITLE
[CD-226] approve component

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -37,7 +37,7 @@ Add a check if you've reviewed the component and it passes the Criteria.
 | cd-tabs             |                     | :heavy_check_mark:  |
 | cd-teaser           | :heavy_check_mark:  | :heavy_check_mark:  |
 | cd-title-list       | :heavy_check_mark:  | :heavy_check_mark:  |
-| cd-toc              |                     | :heavy_check_mark:  |
+| cd-toc              | :heavy_check_mark:  | :heavy_check_mark:  |
 | cd-typography       |                     | :heavy_check_mark:  |
 | cd-utilities        |                     | :heavy_check_mark:  |
 

--- a/components/cd-toc/README.md
+++ b/components/cd-toc/README.md
@@ -3,7 +3,8 @@
 ## Purpose and Usage
 A list of links to page headings for onpage navigation.
 
-Default behaviour is to grow to fit available content. When floated, the width is restricted.
+Default behaviour is to grow to fit available content. When floated, the width
+is restricted.
 
 ## Caveats
 This is currently using cd-utilities for the float rules.


### PR DESCRIPTION
Just noting that the .html template, unlike the others, is a full html document with head and body sections (and 'cd-toc--float-left' class while .twig template has 'cd-toc--float-right'.