### PR TITLE
CD-269: add theme hook suggestions for any Views Display

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -357,6 +357,22 @@ function common_design_theme_suggestions_page_alter(array &$suggestions, array $
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ *
+ * Provides more granularity when Views displays are getting rendered. The two
+ * suggestions will allow the following templates to be picked up:
+ *
+ * - views-view--VIEW.html.twig
+ * - views-view--VIEW--DISPLAY.html.twig
+ *
+ * @see https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Render%21theme.api.php/function/hook_theme_suggestions_HOOK_alter/8.8.x
+ */
+function common_design_theme_suggestions_views_view_alter(&$suggestions, $variables) {
+  $suggestions[] = sprintf('views_view__%s', $variables['view']->id());
+  $suggestions[] = sprintf('views_view__%s__%s', $variables['view']->id(), $variables['view']->current_display);
+}
+
+/**
  * Implements hook_block__language_block().
  */
 function common_design_preprocess_block__language_block(&$vars) {


### PR DESCRIPTION
# CD-269

New feature: Twig template suggestions for any Views Display being rendered.

While implementing CD on a project, I had a particularly protracted battle with Drupal trying to get some Twig templates to be recognized in regards to a specific Views Display. In the end, the code to enable the behavior was quite short and I'd like to add it to Common Design as a more dev-friendly default.

## Before

It either didn't render any suggestions at all, simply reporting that it pulled the CD `views-view.html.twig` or it listed the one option with no alternatives:

```html
<!-- FILE NAME SUGGESTIONS:
   x views-view.html.twig
-->
```

## After

This is a real example of a View with machine key `features` and Display machine key `embed_latest_4`:

```html
<!-- FILE NAME SUGGESTIONS:
   * views-view--features--embed-latest-4.html.twig
   * views-view--features.html.twig
   x views-view.html.twig
-->
```