### PR TITLE
[CD-327] Fix page title logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Dependency updates for xmldom
+- Fix page title logic to limit the use of the page title to node canonical and preview pages
 
 ---
 

--- a/common_design.theme
+++ b/common_design.theme
@@ -115,20 +115,40 @@ function common_design_use_node_page_title($view_mode) {
  * rendered by a page title paragraph or when viewing full article nodes.
  */
 function common_design_preprocess_page(&$variables) {
-  // If the node variable is defined then we assume we are on a node page.
-  // We retrieve the view mode for the page and compare it against the settings
-  // to render the page title inside the node. If so, we hide the page title
-  // and local tasks blocks from their original region in the page.
-  if (isset($variables['node']) && is_a($variables['node'], '\Drupal\node\NodeInterface')) {
-    // This gives us an array with the page view mode for the node.
-    $build = \Drupal::entityTypeManager()
-      ->getViewBuilder('node')
-      ->view($variables['node']);
+  $route_match = \Drupal::routeMatch();
+  $route_name = $route_match->getRouteName();
 
-    if (common_design_use_node_page_title($build['#view_mode'] ?? '')) {
+  // Retrieve the view mode for the node page or preview page.
+  $view_mode = '';
+  if ($route_name === 'entity.node.canonical') {
+    $node = $route_match->getParameter('node');
+    if (!empty($node)) {
+      // This gives us an array with the page view mode for the node.
+      $build = \Drupal::entityTypeManager()
+        ->getViewBuilder('node')
+        ->view($node);
+
+      $view_mode = $build['#view_mode'] ?? '';
+    }
+  }
+  elseif ($route_name === 'entity.node.preview') {
+    $view_mode = $route_match->getParameter('view_mode_id');
+  }
+
+  // If the view mode was selected to use the page title block, then
+  // we remove the original page title block and local tasks blocks.
+  // @see common_design_preprocess_node().
+  // @see common_design_set_page_title().
+  if (common_design_use_node_page_title($view_mode)) {
+    if ($route_name === 'entity.node.canonical') {
       common_design_hide_rendered_blocks_from_page($variables, [
         'page_title_block',
         'local_tasks_block',
+      ]);
+    }
+    elseif ($route_name === 'entity.node.preview') {
+      common_design_hide_rendered_blocks_from_page($variables, [
+        'page_title_block',
       ]);
     }
   }
@@ -137,26 +157,81 @@ function common_design_preprocess_page(&$variables) {
 /**
  * Implements hook_preprocess_node().
  *
- * Use the page title block for the title and display the local tasks below it.
- * We use common_design_get_block_render_array() that will cache the
- * render array of the blocks so that they are not re-rendered and displayed
- * again.
+ * Use the page title block for the node title if the view mode was selected
+ * in the theme settings.
+ *
+ * Important: this assumes there is a template for the view mode that uses
+ * the `title` (and `local_tasks`) variables added by
+ * common_design_use_node_page_title(). See `node--full.html.twig`.
  *
  * @see common_design_preprocess_page()
- * @see common_design_get_block_render_array()
+ * @see common_design_set_page_title()
  */
 function common_design_preprocess_node(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  $node = $variables['node'] ?? NULL;
   $view_mode = $variables['view_mode'] ?? '';
 
-  // Prepare the title and local tasks so we have better control over where
-  // to display them for content in full node.
-  if (common_design_use_node_page_title($view_mode)) {
-    $variables['title'] = common_design_get_block_render_array('page_title_block');
-    $variables['local_tasks'] = common_design_get_block_render_array('local_tasks_block');
+  // If the node view mode was selected to use the page title block for the
+  // node title in the template, then we add the page title to the template
+  // variables. We only do that if we are on the canonical node page or on
+  // the node preview page.
+  if (isset($node) && common_design_use_node_page_title($view_mode)) {
+    if (node_is_page($node)) {
+      common_design_set_page_title($variables, $node->label(), TRUE);
+    }
+    elseif ($node->in_preview && $route_name === 'entity.node.preview') {
+      common_design_set_page_title($variables, $node->label(), FALSE);
+    }
+  }
+}
+
+/**
+ * Set the page title (ex: node page) using the page title block.
+ *
+ * @param array $variables
+ *   Variables as passed to a hook_preprocess_HOOK().
+ * @param string $default_title
+ *   Default title to use if none can be resolved.
+ * @param bool $is_page
+ *   Flag indicating if we are on a normal page as opposed to viewing an entity
+ *   in preview for example, or if this called outside of a page context.
+ */
+function common_design_set_page_title(array &$variables, $default_title, $is_page = FALSE) {
+  // Retrieve the page title block.
+  $variables['title'] = common_design_get_block_render_array('page_title_block');
+  if (!empty($variables['title'])) {
+    // If we are on a normal page (not in a node preview for example), and the
+    // page title render array doesn't have a default title, then we try to get
+    // the title from the title resolver service.
+    // @see https://www.drupal.org/project/drupal/issues/2938129
+    if ($is_page) {
+      if (empty($variables['title']['#title'])) {
+        $request = \Drupal::request();
+        $route_object = \Drupal::routeMatch()->getRouteObject();
+        if (!empty($request) && !empty($route_object)) {
+          $default_title = \Drupal::service('title_resolver')
+            ->getTitle($request, $route_object);
+        }
+      }
+      else {
+        $default_title = $variables['title']['#title'];
+      }
+    }
+
+    // Set the default title.
+    $variables['title']['#title'] = $default_title;
+
     // Copy the title attributes.
-    if (!empty($variables['title']) && !empty($variables['title_attributes'])) {
+    if (!empty($variables['title_attributes'])) {
       $variables['title']['#title_attributes'] = $variables['title_attributes'];
     }
+  }
+
+  // Also pre-render the local tasks when on a normal page.
+  if ($is_page) {
+    $variables['local_tasks'] = common_design_get_block_render_array('local_tasks_block');
   }
 }
 
@@ -456,19 +531,10 @@ function common_design_get_block_render_array($id) {
     $cache->addCacheableDependency($build['#access']);
     $cache->applyTo($build);
 
-    // Ensure the page title block has a title.
-    // @see https://www.drupal.org/project/drupal/issues/2938129
-    if ($id === 'page_title_block' && empty($build['#title'])) {
-      $request = \Drupal::service('request_stack')->getCurrentRequest();
-      $route_object = \Drupal::service('current_route_match')->getRouteObject();
-      $title_resolver = \Drupal::service('title_resolver');
-
-      $build['#title'] = $title_resolver->getTitle($request, $route_object);
-    }
     // The local tasks have by default a max-age cache of 0 which prevents the
     // entire caching so we remove it as there are already cache contexts and
     // tags to ensure its displayed appropriately.
-    elseif ($id === 'local_tasks_block' && empty($build['#cache']['max-age'])) {
+    if ($id === 'local_tasks_block' && empty($build['#cache']['max-age'])) {
       unset($build['#cache']['max-age']);
     }
 

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -89,16 +89,14 @@
 <article{{ attributes.addClass(classes) }}>
 
   {{ title_prefix }}
-  {% if title %}
-    {% if not page %}
-      <h2{{ title_attributes }}>
-        <a href="{{ url }}" rel="bookmark">{{ title }}</a>
-      </h2>
-    {% else %}
-      {# This is not wrapped as this renders the page title block which
-         already wraps the node title in a <h1>. #}
-      {{ title }}
-    {% endif %}
+  {% if title and page %}
+    {# This is not wrapped as this renders the page title block which
+       already wraps the node title in a <h1>. #}
+    {{ title }}
+  {% else %}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
   {% endif %}
   {{ title_suffix }}
 


### PR DESCRIPTION
Ticket: CD-237

As discovered in https://humanitarian.atlassian.net/browse/IASC-716, there may be some occasions where a node is rendered in a view mode selected to use the page title block, outside of the node page, for example when indexing a rendered node with Search API.

Another problem with the current logic is that the node title and local tasks don't appear in the node edit page when using the CD theme for the edit forms.

This PR refines the logic to limit the use of the page title to node canonical and preview pages.

This is compatible with the current logic and so updating any site using the CD theme should be seamless.

**Test**

1. Update any site using the CD with the code from this branch.
2. Check that "full" is selected in the CD settings (should be by default).
3. Visit a node page and check that the node title is indeed using the page title template (enable twig debug if not already) and that the title is inside the `<article>` tag.
4. Edit the node and click preview and check the same as above.

Testing that the page title block is not used in other contexts is more complicated. This can be done for example, by rendering a node in full view mode via an entity reference field:

1. Create a temporary entity reference field for nodes on a node type.
2. In manage display of the node type, select "rendered entity" for the field and the "full" view mode.
3. Create a node and add a another node to the field
4. Save or preview and confirm that the referenced node is using the `node-full.html.twig` template but that the title is wrapped in a `<h2>` and not using the page title template.