### PR TITLE
[CD-329] Fix deprecation of stylelint-no-browser-hacks

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,8 +7,7 @@
     "no-descending-specificity": null,
     "unit-no-unknown": null,
     "unit-allowed-list": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "plugin/no-browser-hacks": null
+    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"]
   },
   "defaultSeverity": "warning"
 }

--- a/common_design_subtheme/.stylelintrc.json
+++ b/common_design_subtheme/.stylelintrc.json
@@ -7,8 +7,7 @@
     "no-descending-specificity": null,
     "unit-no-unknown": null,
     "unit-allowed-list": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "plugin/no-browser-hacks": null
+    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"]
   },
   "defaultSeverity": "error"
 }

--- a/common_design_subtheme/modules/stylelint-no-browser-hacks/lib/index.js
+++ b/common_design_subtheme/modules/stylelint-no-browser-hacks/lib/index.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const stylelint = require("stylelint");
+const ruleName = "plugin/no-browser-hacks";
+
+module.exports = stylelint.createPlugin(ruleName, () => () => {});

--- a/common_design_subtheme/modules/stylelint-no-browser-hacks/package.json
+++ b/common_design_subtheme/modules/stylelint-no-browser-hacks/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "stylelint-no-browser-hacks",
+    "version": "1.0.0",
+    "description": "Dummy module to replace stylelint-no-browser-hacks with a no-op",
+    "files": [
+        "lib/"
+    ]
+}

--- a/common_design_subtheme/package.json
+++ b/common_design_subtheme/package.json
@@ -41,7 +41,7 @@
     "stylelint": "^13.12.0",
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-config-standard": "^21.0.0",
-    "stylelint-no-browser-hacks": "^1.2.1",
+    "stylelint-no-browser-hacks": "file:./modules/stylelint-no-browser-hacks",
     "stylelint-order": "^4.1.0",
     "stylelint-scss": "^3.19.0",
     "svg-sprite": "^1.5.1",

--- a/modules/stylelint-no-browser-hacks/lib/index.js
+++ b/modules/stylelint-no-browser-hacks/lib/index.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const stylelint = require("stylelint");
+const ruleName = "plugin/no-browser-hacks";
+
+module.exports = stylelint.createPlugin(ruleName, () => () => {});

--- a/modules/stylelint-no-browser-hacks/package.json
+++ b/modules/stylelint-no-browser-hacks/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "stylelint-no-browser-hacks",
+    "version": "1.0.0",
+    "description": "Dummy module to replace stylelint-no-browser-hacks with a no-op",
+    "files": [
+        "lib/"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "stylelint": "^13.12.0",
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-config-standard": "^21.0.0",
-    "stylelint-no-browser-hacks": "^1.2.1",
+    "stylelint-no-browser-hacks": "file:./modules/stylelint-no-browser-hacks",
     "stylelint-order": "^4.1.0",
     "stylelint-scss": "^3.19.0",
     "svg-sprite": "^1.5.0",


### PR DESCRIPTION
Ticket: CD-329

See the ticket's description for more details (background etc.)

Basically what this PR does, is to replace the abandoned (?) `stylelint-no-browser-hacks` module with a dummy local one to preserve the compatibility with site using the CD theme with Drupal < 9.2.

@left23 I didn't commit the `package-lock.json` files because my version of `node` and `npm` may be too recent and I'm not sure of the impact. If you think the proposed solution is worthy could you generate and push the lock files?