### PR TITLE
[CD-327] Add compatibility with node template overrides

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -185,15 +185,6 @@ function common_design_preprocess_node(&$variables) {
       common_design_set_page_title($variables, $node->label(), FALSE);
     }
   }
-
-  // Compatibility with node template overrides in sites using the CD theme:
-  // we set the title to the label on non-node pages. This label will be
-  // rendered as h2 (depending on the override) similarly to what is done in
-  // the core node template.
-  // @see Drupal/core/themes/stable/templates/content/node.html.twig
-  if (empty($variables['page']) && !isset($variables['title'])) {
-    $variables['title'] = $variables['label'] ?? $node->label();
-  }
 }
 
 /**

--- a/common_design.theme
+++ b/common_design.theme
@@ -185,6 +185,15 @@ function common_design_preprocess_node(&$variables) {
       common_design_set_page_title($variables, $node->label(), FALSE);
     }
   }
+
+  // Compatibility with node template overrides in sites using the CD theme:
+  // we set the title to the label on non-node pages. This label will be
+  // rendered as h2 (depending on the override) similarly to what is done in
+  // the core node template.
+  // @see Drupal/core/themes/stable/templates/content/node.html.twig
+  if (empty($variables['page']) && !isset($variables['title'])) {
+    $variables['title'] = $variables['label'] ?? $node->label();
+  }
 }
 
 /**

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -89,10 +89,12 @@
 <article{{ attributes.addClass(classes) }}>
 
   {{ title_prefix }}
-  {% if title and page %}
-    {# This is not wrapped as this renders the page title block which
-       already wraps the node title in a <h1>. #}
-    {{ title }}
+  {% if page %}
+    {% if title %}
+      {# This is not wrapped as this renders the page title block which
+         already wraps the node title in a <h1>. #}
+      {{ title }}
+    {% endif %}
   {% else %}
     <h2{{ title_attributes }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>


### PR DESCRIPTION
Ticket: CD-327

This fixes a flaw in the previous page title fix (https://github.com/UN-OCHA/common_design/pull/262) where the node title would be rendered as h2 instead of not being displayed in the template (ex: unselect the page title setting in the CD theme).

In addition this adds compatibility with node template overrides in sites using the CD theme like IASC: https://github.com/UN-OCHA/iasc8/blob/9a31465b063f9c0ac9383fbbb8905534794edc91/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig#L91-L101.

### Tests

**Full view mode in node page and preview**

1. Select "Full" as view mode to use the page title in the CD theme/subtheme settings
2. View a node, check that the title is using the page title template and is inside the `<article>`
3. Edit the node, click "preview" and confirm the above also applies
4. Unselect "Full" in the CD theme/subtheme settings
5. View the node and check that the title is using the page title template but is outside the `<article>` (default Drupal behavior using the page title block)
6. Edit the node, click "preview" and confirm the above also applies

**Full view mode outside of page/preview context**

1. Create a temporary entity reference field for nodes on a node type.
2. In manage display of the node type, select "rendered entity" for the field and the "full" view mode.
3. Create a node and add a another node to the entity reference field.
4. Save or preview and confirm that the referenced node is using the node-full.html.twig template but that the title is wrapped in a `<h2>` and not using the page title template.

