### PR TITLE
CD-258 Translation files in base theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add admin and external link SVG icons to SVG icon sprite
 - Add Pull Request template
 - Add Release Notes template to CONTRIBUTING.md
+- Add Arabic, French, and Spanish translation files for CD Header and Footer user interface strings
 ### Changed
 - Replace external js file with local file for CSS custom property ponyfill
 - Add missing accessibility-related attributes on SVG icons in the sub theme social media partial

--- a/README.md
+++ b/README.md
@@ -333,3 +333,8 @@ See the [Manifest documentation][manifest-docs] for implementation details.
   [brand]: https://web.brand.unocha.org
   [pwa]: https://www.drupal.org/project/pwa
   [manifest-docs]: https://developer.mozilla.org/en-US/docs/Web/Manifest
+
+## Translations
+Arabic, French and Spanish string translation files are available for the Common Design Header and Footer user 
+interface, for example the OCHA Services in the header and the OCHA mandate in the footer. Refer to the `.po` files in
+the `translations` directory and the [README](https://github.com/UN-OCHA/common_design/translations/README.md).

--- a/translations/README.md
+++ b/translations/README.md
@@ -1,0 +1,26 @@
+The included `.po` files contain strings for the Common Design Header and Footer user interface, in some (not all) of
+the UN official languages. These can be expanded upon as language requirements arise.
+
+# Translation files
+
+A few notes related to the translation of hardcoded strings in themes and modules.
+
+## Importing translations
+
+Visit `/admin/config/regional/translate/import` and upload the file of your choice. Select all three configuration options when importing the file.
+
+## Exporting translations
+
+Visit `/admin/config/regional/translate/export` and download the file of your choice. Select all three configuration options when exporting your file.
+
+## Creating translations
+
+As an admin, visit `/admin/config/regional/translate`
+
+When using the translation interface, you must load a page containing the string to be translated in the NON-original language at least once. So for instance if there's a new paragraph type to be translated, the process would be:
+
+1. As admin, add the new paragraph type to an English node. This is because you cannot add new paragraphs to translations of pages. It must first be in the original.
+2. As admin, navigate to the translation of the node, or create a new one. Save the node.
+3. View the new translated node.
+4. Now you can proceed to the translation admin UI (see URL path above).
+5. Once all translations are complete, **export the PO file** and replace the one in this directory. It still must be imported into the environment of interest, but storing them in version control ensures that we don't lose them due to content wipes and the like.

--- a/translations/ar-common-design.po
+++ b/translations/ar-common-design.po
@@ -1,0 +1,56 @@
+# Arabic translation of Common Design Header and Footer
+#
+msgid "Skip to main content"
+msgstr "اذهب الى المحتوى الرئيسي"
+
+msgid "Related Platforms"
+msgstr "المنصات ذات الصلة"
+
+msgid "Other OCHA Services"
+msgstr ""
+"الخدمات الأخرى لمكتب تنسيق الشؤون "
+"الإنسانية"
+
+msgid "See all"
+msgstr "الإطلاع على الكل"
+
+msgid "Log in"
+msgstr "تسجيل الدخول"
+
+msgid "My account"
+msgstr ""
+
+msgid "Log out"
+msgstr ""
+
+msgid "Service provided by"
+msgstr "الخدمة مقدمة من قبل"
+
+msgid ""
+"OCHA coordinates the global emergency response to save lives and "
+"protect people in humanitarian crises. We advocate for effective and "
+"principled humanitarian action by all, for all."
+msgstr ""
+"ينسق مكتب تنسيق الشؤون الإنسانية "
+"الاستجابة العالمية للطوارئ لإنقاذ "
+"الأرواح وحماية الأشخاص في الأزمات "
+"الإنسانية. نحن ندعو إلى العمل الإنساني "
+"الفعال والقائم على المبادئ من قبل "
+"الجميع وللجميع."
+
+msgid ""
+"Except where otherwise noted, content on this site is licensed under a "
+"<a href=\"https://creativecommons.org/licenses/by/4.0/\">Creative "
+"Commons Attribution 4.0</a> International license."
+msgstr ""
+"ما لم يذكر خلاف ذلك، إن المحتوى "
+"الموجود على هذا الموقع مرخص بموجب "
+"ترخيص <a "
+"href=\"https://creativecommons.org/licenses/by/4.0/deed.ar\">Creative "
+"Commons Attribution 4.0 International License</a>."
+
+msgid "OCHA Services"
+msgstr "خدمات مكتب تنسيق الشؤون الإنسانية"
+
+msgid "Creative Commons BY 4.0"
+msgstr "Creative Commons BY 4.0"

--- a/translations/es-common-design.po
+++ b/translations/es-common-design.po
@@ -1,0 +1,51 @@
+# Spanish translation of Common Design Header and Footer
+#
+msgid "Skip to main content"
+msgstr "Ir al contenido principal"
+
+msgid "Related Platforms"
+msgstr "Plataformas relacionadas"
+
+msgid "Other OCHA Services"
+msgstr "Otros servicios de OCHA"
+
+msgid "See all"
+msgstr "Ver todo"
+
+msgid "Log in"
+msgstr "Iniciar sesión"
+
+msgid "My account"
+msgstr ""
+
+msgid "Log out"
+msgstr ""
+
+msgid "Service provided by"
+msgstr "Servicio ofrecido por"
+
+msgid ""
+"OCHA coordinates the global emergency response to save lives and "
+"protect people in humanitarian crises. We advocate for effective and "
+"principled humanitarian action by all, for all."
+msgstr ""
+"OCHA coordina la respuesta humanitaria a emergencias a nivel global, "
+"para salvar vidas y proteger a las personas en crisis humanitarias. "
+"Abogamos por una acción humanitaria eficaz y basada en principios de "
+"todos y para todos."
+
+msgid ""
+"Except where otherwise noted, content on this site is licensed under a "
+"<a href=\"https://creativecommons.org/licenses/by/4.0/\">Creative "
+"Commons Attribution 4.0</a> International license."
+msgstr ""
+"Salvo que se indique lo contrario, el contenido de este sitio web "
+"tiene una licencia <a "
+"href=\"https://creativecommons.org/licenses/by/4.0/deed.es\">Creative "
+"Commons Attribution 4.0 International</a>."
+
+msgid "OCHA Services"
+msgstr "Servicios de OCHA"
+
+msgid "Creative Commons BY 4.0"
+msgstr "Creative Commons BY 4.0"

--- a/translations/fr-common-design.po
+++ b/translations/fr-common-design.po
@@ -1,0 +1,51 @@
+# French translation of Common Design Header and Footer
+#
+msgid "Skip to main content"
+msgstr "Aller au contenu principal"
+
+msgid "Related Platforms"
+msgstr "Plateformes associées"
+
+msgid "Other OCHA Services"
+msgstr "Autres services OCHA"
+
+msgid "See all"
+msgstr "Tout voir"
+
+msgid "Log in"
+msgstr "S'identifier"
+
+msgid "My account"
+msgstr ""
+
+msgid "Log out"
+msgstr ""
+
+msgid "Service provided by"
+msgstr "Service fourni par"
+
+msgid ""
+"OCHA coordinates the global emergency response to save lives and "
+"protect people in humanitarian crises. We advocate for effective and "
+"principled humanitarian action by all, for all."
+msgstr ""
+"OCHA coordonne la réponse globale pour sauver des vies et protéger "
+"les personnes en cas de crises humanitaires. Nous plaidons en faveur "
+"de la mise en oeuvre, par tous et pour tous, d’une action "
+"humanitaire efficace et fondée sur des principes."
+
+msgid ""
+"Except where otherwise noted, content on this site is licensed under a "
+"<a href=\"https://creativecommons.org/licenses/by/4.0/\">Creative "
+"Commons Attribution 4.0</a> International license."
+msgstr ""
+"Sauf indication contraire, le contenu de ce site est concédé sous "
+"une licence <a "
+"href=\"https://creativecommons.org/licenses/by/4.0/deed.fr\">Creative "
+"Commons Attribution 4.0 International</a>."
+
+msgid "OCHA Services"
+msgstr "Services OCHA"
+
+msgid "Creative Commons BY 4.0"
+msgstr "Creative Commons BY 4.0"


### PR DESCRIPTION
## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Security update (dependency updates, or to fix a vulnerability)

## Description
 - Copy `.po` files from [common-design-site](https://github.com/UN-OCHA/common-design-site/tree/develop/translations) root to base theme and add note at the top of readme

## Motivation and Context
Since the strings are related specifically to the CD Header and Footer UI, the translation files should be in the same place.

## Impact
Translation files for Arabic, Spanish, and French for the CD Header and Footer are now part of the repo so any implementations using this as a base theme can avail of these and updates from now on.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have included a CHANGELOG entry with th PR.
- [ ] My PR passes tests.
- [ ] I have linted my code locally.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
