### PR TITLE
CD-334 Add item about changes to sub theme in the PR checklist

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,14 +2,11 @@
 
 ## Types of changes
 <!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
-
-| :------------------| :---------------------------------------------------------------------------------------------- |
-| :heavy_check_mark: | Improvement (non-breaking change which iterates on an existing feature)
-|                    | Bug fix (non-breaking change which fixes an issue)
-|                    | New feature (non-breaking change which adds functionality)
-|                    | Breaking change (fix or feature that would cause existing functionality to not work as expected)
-|                    | Security update (dependency updates, or to fix a vulnerability)
-
+- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Security update (dependency updates, or to fix a vulnerability)
 
 ## Description
 <!--- Describe your changes in detail -->
@@ -37,7 +34,7 @@ How does the proposed change impact existing implementations? What action is nee
 ## PR Checklist
 <!--- Put an `x` in all the boxes that apply. -->
 - [ ] I have included a CHANGELOG entry with the PR.
-- [ ] My PR passes tests.
+- [ ] I have run local tests and the tests pass.
 - [ ] I have linted my code locally.
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,13 @@
 <!-- Delete any parts of this template not applicable to your Pull Request. -->
 
 ## Types of changes
-<!--- Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Security update (dependency updates, or to fix a vulnerability)
+<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
+
+| ------------------ |------------------------------------------------
+| :heavy_check_mark: | Bug fix (non-breaking change which fixes an issue)
+|                    | New feature (non-breaking change which adds functionality)
+|                    | Breaking change (fix or feature that would cause existing functionality to not work as expected)
+|                    | Security update (dependency updates, or to fix a vulnerability)
 
 ## Description
 <!--- Describe your changes in detail -->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -38,3 +38,4 @@ How does the proposed change impact existing implementations? What action is nee
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
+- [ ] I have made changes to the sub theme to reflect those in the base theme


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->
## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Add item to the PR template to prompt when changes to the base theme also need to be made in the sub theme.

## Motivation and Context
I think this is something being overlooked, as https://humanitarian.atlassian.net/browse/CD-328?focusedCommentId=129222 points out.

## Expected behavior
Sub theme should be insync with base theme

## Actual behavior
Sub theme version is not updated past its initial copying from the base theme into `/themes/custom/` despite changes to the package.json (dependency fixes) and numerous other implementation specific changes.

  
## Impact
This would serve as a check for devs opening PRs to remember to check whether the changes they make need to also be reflected in the sub theme, either in the base theme repo, or the implementation specific sub theme.

This is a start to develop how we better version the sub theme.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have included a CHANGELOG entry with th PR.
- [ ] My PR passes tests.
- [ ] I have linted my code locally.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
