### PR TITLE
CD-329 Remove stylelint and unit-whitelist, and plugin/no-browser-hacks from sub theme

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,8 +6,7 @@
   "rules": {
     "no-descending-specificity": null,
     "unit-no-unknown": null,
-    "unit-allowed-list": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"]
+    "unit-allowed-list": ["ch", "deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"]
   },
   "defaultSeverity": "warning"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Add `ch` unit to `unit-allowed-list` stylelint configuration
 ### Changed
 - Mention D9 in README
 - Fix some links in `CONTRIBUTING.md`
+### Removed
+- Remove `unit-whitelist` from stylelint configuration as it is deprecated
+- Remove `plugin/no-browser-hacks` from sub theme stylelint configuration. See [issues #265](https://github.com/UN-OCHA/common_design/issues/265).
+The base theme and sub theme are now tailored for >= Drupal 9.2
 ### Security
 - Dependency updates for nth-check
 ---

--- a/common_design_subtheme/.stylelintrc.json
+++ b/common_design_subtheme/.stylelintrc.json
@@ -6,9 +6,7 @@
   "rules": {
     "no-descending-specificity": null,
     "unit-no-unknown": null,
-    "unit-allowed-list": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "unit-whitelist": ["deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"],
-    "plugin/no-browser-hacks": null
+    "unit-allowed-list": ["ch", "deg", "em", "ex", "ms", "rem", "%", "s", "px", "vw", "vh", "fr", "pt", "$cd-container-padding"]
   },
   "defaultSeverity": "error"
 }


### PR DESCRIPTION
## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)

## Description
- Add `ch` unit to `unit-allowed-list` stylelint configuration
- Remove `unit-whitelist` from stylelint configuration as it is deprecated
- Remove `plugin/no-browser-hacks` from sub theme stylelint configuration. See [issues #265](https://github.com/UN-OCHA/common_design/issues/265). The base theme and sub theme are now tailored for >= Drupal 9.2

## Motivation and Context
Closing some items in the backlog.

## Impact
See #265 
After updating the node packages `npm i` we can run `npm run sass:lint` without deprecation warnings or missing plugin errors.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have included a CHANGELOG entry with the PR
- [x] My code follows the code style of this project.
- [x] I have made changes to the sub theme to reflect those in the base theme
