### PR TITLE
[CD-356] Datetime_wrapper title visibility

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -774,3 +774,13 @@ function common_design_preprocess_fieldset(array &$variables) {
   }
 }
 
+/**
+ * Implements hook_preprocess_datetime_wrapper().
+ */
+function common_design_preprocess_datetime_wrapper(&$variables) {
+  // Ensure the title is not displayed when instructed to be hidden.
+  if (isset($variables['element']['#title_display']) && $variables['element']['#title_display'] === 'invisible') {
+    $variables['title_attributes']['class'][] = 'visually-hidden';
+  }
+}
+


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
<!--- Describe your changes in detail -->

Implement `hook_preprocess_datetime_wrapper()` to ensure the datetime_wrapper title is not displayed when instructed to be hidden.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The [datetime_wrapper preprocessing function](https://api.drupal.org/api/drupal/core%21includes%21theme.inc/function/template_preprocess_datetime_wrapper/9.3.x) doesn’t handle the ‘#title_display’ property of the form element and notably doesn’t hide the title when set to `invisible`.

Issue: https://humanitarian.atlassian.net/browse/CD-356

## Expected behavior
<!--- Describe what should happen. -->

The datetime wrapper title should be hidden when the `#title_display` property is set to `invisible`.

## Actual behavior
<!--- Describe what actually happens. -->

The datetime wrapper title is not hidden when the `#title_display` property is set to `invisible`.

## Steps to reproduce the problem or Steps to test

1. Create a new datetime field on a entity (ex: a node), example `field_event_date`.
2. Implement a `hook_form_alter()` somewhere, and set `$form['field_event_date']['widget'][0]['value']['#title_display'] = 'invisible';` to hide instruct drupal to hide the field label.
3. Check that the field is not hidden without this patch and hidden when the `common_design_preprocess_datetime_wrapper` is present.
  
## Impact

Non breaking improvement so normally no impact except for sites that expect Drupal to behave properly.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have included a CHANGELOG entry with the PR.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
