### PR TITLE
[CD-373] SVG sprite inclusion

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -406,17 +406,6 @@ function common_design_form_alter(&$form, FormStateInterface $form_state, $form_
  * Implements hook_preprocess_html().
  */
 function common_design_preprocess_html(&$vars) {
-  // SVG sprite
-  // Get the contents of the SVG sprite.
-  $icons = file_get_contents(drupal_get_path('theme', 'common_design') . '/img/icons/cd-icons-sprite.svg');
-
-  // Add a new render array to page_bottom so the icons
-  // get added to the page.
-  $vars['page_bottom']['icons'] = [
-    '#type' => 'inline_template',
-    '#template' => '<span class="hidden">' . $icons . '</span>',
-  ];
-
   // Check if current request is an exception to get error type.
   $status_code = \Drupal::requestStack()->getCurrentRequest()->attributes->get('exception');
 

--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -1,45 +1,38 @@
 # OCHA Common Design sub theme for Drupal 8/9
 
-A sub theme, extending [common_design](https://github.com/UN-OCHA/common_design) base theme.
+A sub-theme, for implementing the [common_design](https://github.com/UN-OCHA/common_design) base-theme in a way that allows for "upstream" changes such as security updates, new features, and so forth. The subtheme is ready to help you implement the following types of customizations:
 
-This can be used as a starting point for implementations. Add components, override and extend base theme as needed.
+- Modifying the Common Design, such as customizing its colors
+- override/extend base theme templates
+- adding/overriding/extending frontend components
+
 Refer to [Drupal 8+ Theming documentation](https://www.drupal.org/docs/theming-drupal) for more.
 
-Copy this directory to `/themes/custom/`, then rename the `common_design_subtheme.info.yml.example` to
-`common_design_subtheme.info.yml`.
+## Getting started
+1. Copy this directory to `/themes/custom/`
+2. Rename the `common_design_subtheme.info.yml.example` to `common_design_subtheme.info.yml`
 
 ### Customise the logo
-- Set the logo `logo: 'img/logos/logo.svg'` in the `common_design_subtheme.info.yml` file, and in the
-`sass/cd/cd-header/_cd-logo.scss` partial override file.
+- Set the logo `logo: 'img/logos/logo.svg'` in the `common_design_subtheme.info.yml` file, and in the `sass/cd/cd-header/_cd-logo.scss` partial override file.
 - Adjust the grid column width in `sass/cd/cd-header/_cd-header.scss` partial override file to accommodate the logo.
 
 ### Customise the favicon and homescreen icons
 Replace the favicon in the theme's root, and the homescreen icons in `img/` with branded versions
 
 ### Customise colours
-- Change colour-related variable names and values in `sass/cd/_cd_variables.scss` and replace in all references to in
-partial overrides in `common_design_subtheme/sass/cd/`
+- Change colour-related variable names and values in `sass/cd/_cd_variables.scss` and replace in all references to in partial overrides in `common_design_subtheme/sass/cd/`
 
 ### Customise icons
-- Copy SVG icons from the [Humanitarian icon set](https://brand.unocha.org/d/xEPytAUjC3sH/icons) into the subtheme `img/icons` directory and follow the
-instructions in the [common_design README](https://github.com/UN-OCHA/common_design/#icons) to generate a sprite with those new icons.
-- Edit the subtheme's `templates/cd/cd-icons/cd-icons.html.twig` to include the
-generated sprite file.
+- Copy SVG icons from the [Humanitarian icon set](https://brand.unocha.org/d/xEPytAUjC3sH/icons) into the subtheme `img/icons` directory and follow the instructions in the [common_design README](https://github.com/UN-OCHA/common_design/#icons) to generate a sprite with those new icons.
+- Edit the subtheme's `templates/cd/cd-icons/cd-icons.html.twig` to include the generated sprite file.
 
 ### Other customisations
-Override sass partials and extend twig templates from the base theme as needed, copying them into the sub theme and
-linking them using `@import` for sass and `extend` or `embed` for twig templates.
+Override sass partials and extend twig templates from the base theme as needed, copying them into the sub theme and linking them using `@import` for sass and `extend` or `embed` for twig templates.
 
-Add new components by defining new libraries in `common_design_subtheme.libraries.yml` and attaching them to relevant
-templates. Or use existing components from `common_design.libraries.yml` base theme by attaching the libraries to twig
-template overrides in the sub theme.
-`{{ attach_library('common_design/cd-teaser') }}`
+Add new components by defining new libraries in `common_design_subtheme.libraries.yml` and attaching them to relevant templates. Or use existing components from `common_design.libraries.yml` base theme by attaching the libraries to twig template overrides in the sub theme: `{{ attach_library('common_design/cd-teaser') }}`
 
 Override theme preprocess functions by copying from `common_design.theme` and editing as needed.
 
-Refer to [common_design README](https://github.com/UN-OCHA/common_design/#common-design-base-theme-for-drupal-89) for
-general details about base theme and instructions for compilation. There should be no need to compile the base theme,
-only the sub theme.
+Refer to [common_design README](https://github.com/UN-OCHA/common_design/#common-design-base-theme-for-drupal-89) for general details about base theme and instructions for compilation. There should be no need to compile the base theme, only the sub theme.
 
-Refer to [common_design README E2E testing](https://github.com/UN-OCHA/common_design/#e2e-testing) for information about
-running tests.
+Refer to [common_design README E2E testing](https://github.com/UN-OCHA/common_design/#e2e-testing) for information about running tests.

--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -21,10 +21,8 @@ Replace the favicon in the theme's root, and the homescreen icons in `img/` with
 partial overrides in `common_design_subtheme/sass/cd/`
 
 ### Customise icons
-- Copy SVG icons from the [Humanitarian icon set](https://reliefweb.int/report/world/humanitarian-and-country-icons-2018)
-into the subtheme `img/icons` directory and follow the instructions in the
-[common_design README](https://github.com/UN-OCHA/common_design/#icons) to
-generate a sprite with those new icons.
+- Copy SVG icons from the [Humanitarian icon set](https://brand.unocha.org/d/xEPytAUjC3sH/icons) into the subtheme `img/icons` directory and follow the
+instructions in the [common_design README](https://github.com/UN-OCHA/common_design/#icons) to generate a sprite with those new icons.
 - Edit the subtheme's `templates/cd/cd-icons/cd-icons.html.twig` to include the
 generated sprite file.
 

--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -20,6 +20,14 @@ Replace the favicon in the theme's root, and the homescreen icons in `img/` with
 - Change colour-related variable names and values in `sass/cd/_cd_variables.scss` and replace in all references to in
 partial overrides in `common_design_subtheme/sass/cd/`
 
+### Customise icons
+- Copy SVG icons from the [Humanitarian icon set](https://reliefweb.int/report/world/humanitarian-and-country-icons-2018)
+into the subtheme `img/icons` directory and follow the instructions in the
+[common_design README](https://github.com/UN-OCHA/common_design/#icons) to
+generate a sprite with those new icons.
+- Edit the subtheme's `templates/cd/cd-icons/cd-icons.html.twig` to include the
+generated sprite file.
+
 ### Other customisations
 Override sass partials and extend twig templates from the base theme as needed, copying them into the sub theme and
 linking them using `@import` for sass and `extend` or `embed` for twig templates.
@@ -29,9 +37,7 @@ templates. Or use existing components from `common_design.libraries.yml` base th
 template overrides in the sub theme.
 `{{ attach_library('common_design/cd-teaser') }}`
 
-Override theme preprocess functions by copying from `common_design.theme` and editing as needed. For example, if new
-icons are added, a new icon sprite will need to be generated and the `common_design_preprocess_html` hook used to attach
-the icon sprite to the page will need a new path to reflect the sub theme's icon sprite location.
+Override theme preprocess functions by copying from `common_design.theme` and editing as needed.
 
 Refer to [common_design README](https://github.com/UN-OCHA/common_design/#common-design-base-theme-for-drupal-89) for
 general details about base theme and instructions for compilation. There should be no need to compile the base theme,

--- a/common_design_subtheme/templates/cd/cd-icons/cd-icons.html.twig
+++ b/common_design_subtheme/templates/cd/cd-icons/cd-icons.html.twig
@@ -1,0 +1,6 @@
+{% include '@common_design/cd/cd-icons/cd-icons.html.twig' %}
+
+{# Uncomment the code below to add an additional icon sprite #}
+{# <div class="hidden">
+  {% include '@common_design_subtheme/../img/icons/cd-icons-sprite.svg' %}
+</div> #}

--- a/common_design_subtheme/templates/layout/html.html.twig
+++ b/common_design_subtheme/templates/layout/html.html.twig
@@ -1,0 +1,7 @@
+{% embed '@common_design/layout/html.html.twig' %}
+
+  {% block icons %}
+    {% include '@common_design_subtheme/cd/cd-icons/cd-icons.html.twig' %}
+  {% endblock %}
+
+{% endembed %}

--- a/templates/cd/cd-icons/cd-icons.html.twig
+++ b/templates/cd/cd-icons/cd-icons.html.twig
@@ -1,0 +1,11 @@
+{#
+
+/**
+ * @file
+ * Template to include SVG sprites used for the icons across the site.
+ */
+
+#}
+<div class="hidden">
+  {% include '@common_design/../img/icons/cd-icons-sprite.svg' %}
+</div>

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -50,6 +50,11 @@
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}
+
+    {% block icons %}
+    {% include '@common_design/cd/cd-icons/cd-icons.html.twig' %}
+    {% endblock %}
+
     <js-bottom-placeholder token="{{ placeholder_token }}">
   </body>
 </html>


### PR DESCRIPTION
Refs: CD-373

## Types of changes

- Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- :heavy_check_mark: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description

Include the icon SVG sprite via a template rather than via the `hook_preprocess_html()`.

## Motivation and Context

The current "recommended" way to extend the SVG sprite in the subtheme is to implement a `hook_preprocess_html()` in the subtheme similarly to what is done in the base theme.

This hook approach means fetching and including the content of the SVG sprite on every page call depending on the caching settings of the site. 

When extended in the subtheme, this results in both the base theme and subtheme sprites to be fetched.

Twig templates are cached so including the SVG sprite via a template would be more efficient and more flexible as it would notably be possible to completely skip loading the base theme sprite.

## Expected behavior

The end result should be the same as the current behavior with the SVG sprite added at the bottom of the HTML.

## Actual behavior

The SVG sprite is embedded at the bottom of the HTML.

## Steps to reproduce the problem or Steps to test

1. Install the base theme + subtheme in a Drupal site and enable the subtheme
2. Look for the SVG sprite code in the HTML source of a page before switching to this branch
3. Switch to this branch, clear the cache
4. Check that the SVG sprite code is the same
5. Copy the `img/icons/cd-icons.svg` file from the base theme into the subtheme
6. Edit this sprite, replace the `cd-icon--creative-commons` with whatever icon
7. Edit the subtheme's `templates/cd-icons/cd-icons.html.twig` to include the subtheme `cd-icons.svg`
8. Clear the cache
9. Reload a page and check that the CC icon in the footer shows the icon replacement from above

## Impact

For sites that don't override or modify the SVG sprites (most I think except for RW9) and don't override the `html.html.twig` (most I think except for GHO), there would be no impact.

## Upgrading

### Case 1: site without icon sprite or html template overrides

1. Update the base theme. 
2. Optionally copy the CD/subtheme's `templates/layout/html.html.twig` and `templates/cd-icons/cd-icons.html.twig` into the site subtheme to ease overriding the icons in the future.

### Case 2: site with icon sprite override but no html template override

1. Update the base theme.
2. Copy the CD/subtheme's `templates/layout/html.html.twig` and `templates/cd-icons/cd-icons.html.twig` into the site subtheme.
3. Edit the `templates/cd-icons/cd-icons.html.twig` to include the site subtheme's cd-icons.svg.
4. Remove the relevant SVG inclusion part from the subtheme hook_preprocess_html().

### Case 3: site without icon sprite override but with html template override

1. Update the base theme.
2. Optionally edit the site subtheme `html.html.twig` to add the `icons` block.
2. Optionally copy the CD/subtheme's `templates/cd-icons/cd-icons.html.twig` into the site subtheme.

### Case 4: site with icon sprite override and html template override

1. Update the base theme.
2. Edit the site subtheme `html.html.twig` to add the `icons` block.
3. Copy the CD/subtheme's `templates/cd-icons/cd-icons.html.twig` into the site subtheme.
4. Edit the `templates/cd-icons/cd-icons.html.twig` to include the site subtheme's cd-icons.svg.
5. Remove the relevant SVG inclusion part from the subtheme hook_preprocess_html().6. 

**Note:** for sites that don't use `common_design_subtheme` as name for the subtheme, replace `@common_design_subtheme` in the templates mentioned above, accordingly.

## PR Checklist

- [x] I have included a CHANGELOG entry with the PR.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have made changes to the sub theme to reflect those in the base theme
