### PR TITLE
[CD-364] Ensure proper ID hierarchy in menu templates

### DIFF
--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -37,6 +37,8 @@
       ]
     %}
 
+    {% set parent_id = attributes.id ?? ('cd-user-menu-' ~ menu_level) %}
+
     <ul{{ attributes.addClass(menu_classes) }}>
 
     {% for item in items %}
@@ -50,7 +52,7 @@
       %}
 
       {% set title = item.title == '%username%' ? username : item.title %}
-      {% set id = ('cd-user-menu-item-' ~ menu_level ~ '-' ~ loop.index)|clean_id %}
+      {% set id = (parent_id ~ '-item-' ~ loop.index)|clean_id %}
 
       <li{{ item.attributes.addClass(classes) }}>
 

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -37,6 +37,8 @@
       ]
     %}
 
+    {% set parent_id = attributes.id ?? ('cd-help-menu-' ~ menu_level) %}
+
     <ul{{ attributes.addClass(menu_classes) }}>
 
     {% for item in items %}
@@ -50,7 +52,7 @@
       %}
 
       {% set title = item.title %}
-      {% set id = ('cd-help-menu-item-' ~ menu_level ~ '-' ~ loop.index)|clean_id %}
+      {% set id = (parent_id ~ '-item-' ~ loop.index)|clean_id %}
 
       <li{{ item.attributes.addClass(classes) }}>
 

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -35,6 +35,8 @@
         menu_level > 0 ? 'cd-main-menu__dropdown',
       ]
     %}
+    
+    {% set parent_id = attributes.id ?? ('cd-main-menu-' ~ menu_level) %}
 
     <ul{{ attributes.addClass(menu_classes) }}>
 
@@ -49,7 +51,7 @@
       %}
 
       {% set title = item.title == '%username%' ? username : item.title %}
-      {% set id = ('cd-main-menu-item-' ~ menu_level ~ '-' ~ loop.index)|clean_id %}
+      {% set id = (parent_id ~ '-item-' ~ loop.index)|clean_id %}
 
       <li{{ item.attributes.addClass(classes) }}>
 
@@ -60,7 +62,7 @@
           If the menu item has children, an id attribute and value is added.
         #}
         {% if item.url %}
-        <a href="{{ item.url }}"{% if item.below %} id="{{ id }}"{% endif %}><span>{{ title }}</span></a>
+        <a href="{{ item.url }}" id="{{ id }}"><span>{{ title }}</span></a>
         {% else %}
         <span id="{{ id }}">{{ title }}</span>
         {% endif %}


### PR DESCRIPTION
Refs: CD-364

## Types of changes

- :heavy_check_mark:Bug fix (non-breaking change which fixes an issue)

## Description

Ensure proper ID hierarchy in the account, help and main menu templates.

## Motivation and Context

IDs were duplicated for children items across menu items, causing accessibility issues.

## Expected behavior

List item IDs should be unique now.

## Actual behavior

IDs are duplicated for children items across menu items.

## Steps to reproduce the problem or Steps to test

1. Create menu entries with children for the main menu
2. Without this PR, checks the IDS, there should be duplicates like `cd-main-menu-item-1-1`.
3. With the change from this PR such IDs should be changed to `cd-main-menu-0-1-item-1` etc.

## Impact

This should not have impacts on existing site that use the base theme `navigation/menu--main.html.twig`.

Sites like GHO-2022 overriding this template should path the template override with the changes from this PR.

## PR Checklist

- [x] I have included a CHANGELOG entry with the PR.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
