### PR TITLE
[CD-382] visual indicator for unpublished nodes

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -13,6 +13,7 @@ libraries:
   - common_design/cd-button
   - common_design/cd-dropdown
   - common_design/cd-flow
+  - common_design/cd-nodes
   - common_design/cd-utilities
 
 # Regions

--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -232,6 +232,11 @@ cd-link-list:
   dependencies:
     - common_design/css-vars-ponyfill
 
+cd-nodes:
+  css:
+    component:
+      components/cd-nodes/cd-nodes.css: {}
+
 cd-page-title:
   css:
     component:

--- a/components/cd-nodes/README.md
+++ b/components/cd-nodes/README.md
@@ -1,0 +1,16 @@
+# Drupal Nodes
+
+## Purpose and Usage
+A collection of enhancements for Drupal nodes. They rely on classes that come out of core, but you can adopt these on other entities by preprocessing and causing the same classes to be output on other entities. Here's a list of enhancements the component provides:
+
+- Visual indicator for unpublished nodes
+
+## Caveats
+None
+
+### Variants
+
+```
+none
+
+```

--- a/components/cd-nodes/cd-nodes.css
+++ b/components/cd-nodes/cd-nodes.css
@@ -1,0 +1,6 @@
+/**
+ * CD enhancements for Drupal Nodes
+ */
+.node--unpublished {
+  background: #fdd;
+}


### PR DESCRIPTION
# CD-382

## Types of changes
- New feature (non-breaking change which adds functionality)

## Description
When your user has sufficient permissions to view unpublished nodes, they will appear with a salmon background color instead of the default.

## Motivation and Context
We keep applying this to many websites. This makes it official.

## Steps to reproduce or test

  1. Log in as a user with permissions to view unpublished content (user/1 is an easy choice)
  1. Create a new node and make sure the "Published" checkbox is NOT checked when you save.
  1. Review the node and confirm that the light pink background-color is present.

<img width="1235" alt="CD-382-unpublished" src="https://user-images.githubusercontent.com/254753/165519125-4851249f-1b0d-4126-9f4a-bc0e6cd37f50.png">

## Impact
If individual websites were applying this manually, they can remove that code if they wish. If the website had more complicated logic than checking for `.node--unpublished` then it might be necessary to leave the site-specific rules in place.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.