### PR TITLE
[CD-388] Adopt brand colors in CD Button

### DIFF
--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -7,8 +7,7 @@
    * In the future the Component library will adhere to these vars as well.
    */
   --brand-primary: var(--cd-ocha-blue);
-  --brand-primary--light: var(--cd-blue--bright);
-  --brand-primary--lighter: var(--cd-blue--brighter);
+  --brand-primary--light: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -8,6 +8,7 @@
    */
   --brand-primary: var(--cd-ocha-blue);
   --brand-primary--light: var(--cd-blue--bright);
+  --brand-primary--lighter: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/components/cd-button/cd-button.css
+++ b/components/cd-button/cd-button.css
@@ -1,31 +1,8 @@
-:root {
-  /* Define the Primary colour. */
-  /* Based on OCHA brand guidelines */
-  /* Page 22 https://www.dropbox.com/s/j6tgps8u4u1ht4j/01_visual_identity.pdf?dl=1 */
-
-  /* Custom properties for IE.
-  /* This is needed due to inability to process calc() functions nested within color functions */
-  --cd-ie-primary-color: #1f69b3;
-  --cd-ie-primary-color--light: #82b5e9;
-  --cd-ie-primary-color--dark: #0b2641;
-  --cd-ie-primary-color--lighter: #a8ccf0;
-  --cd-ie-highlight-red: #eb5c6d;
-  --cd-ie-highlight-red--light: #f08995;
-  --cd-primary-color-h: 210;
-  --cd-primary-color-s: 70%;
-  --cd-primary-color-l: 41%;
-  --cd-primary-color: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), var(--cd-primary-color-l));
-
-  /* lighten */
-  --cd-primary-color--light: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) + 30%));
-
-  /* darken */
-  --cd-primary-color--dark: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) - 26%));
-
-  /* For cd-button--light */
-  /* Change the lightness. Other values remain the same */
-  --cd-primary-color--lighter: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) + 39%));
-}
+/**
+ * CD Button
+ *
+ * Defines default button styles plus many variants to suit different use-cases.
+ */
 
 /* Default button */
 .cd-button {
@@ -39,79 +16,36 @@
   color: var(--cd-white);
   border: 2px solid transparent;
   border-radius: 3px;
-  background-color: var(--cd-primary-color);
+  background-color: var(--brand-primary);
   box-shadow: none;
   font-size: 1rem;
   line-height: 1.15;
   -webkit-appearance: none;
 }
 
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button {
-    background-color: var(--cd-ie-primary-color);
-  }
-}
-
 .cd-button:hover,
 .cd-button:focus {
   color: var(--cd-white);
-  background-color: var(--cd-primary-color--light);
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button:hover,
-  .cd-button:focus {
-    background-color: var(--cd-ie-primary-color--light);
-  }
+  background-color: var(--brand-primary--light);
 }
 
 .cd-button:focus {
-  border: 2px solid var(--cd-primary-color--dark);
+  border: 2px solid var(--brand-primary--dark);
   /* We remove the outline because we are adding a border. */
   /* so the rounded corners look nicer on hover */
-  outline: 0 solid var(--cd-primary-color--light);
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button:focus {
-    border: 2px solid var(--cd-ie-primary-color--dark);
-    /* We remove the outline because we are adding a border. */
-    /* so the rounded corners look nicer on hover */
-    outline: 0 solid var(--cd-ie-primary-color--light);
-  }
+  outline: 0 solid var(--brand-primary--light);
 }
 
 /* For buttons on dark backgrounds */
 .cd-button--light {
-  color: var(--cd-primary-color--dark);
-  background-color: var(--cd-primary-color--lighter);
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  /* For buttons on dark backgrounds */
-  .cd-button--light {
-    color: var(--cd-ie-primary-color--dark);
-    background-color: var(--cd-ie-primary-color--lighter);
-  }
+  color: var(--brand-primary--dark);
+  background-color: var(--brand-primary--lighter);
 }
 
 .cd-button--light:hover,
 .cd-button--light:focus {
-  color: var(--cd-primary-color--dark);
-  background-color: var(--cd-primary-color--light);
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--light:hover,
-  .cd-button--light:focus {
-    color: var(--cd-ie-primary-color--dark);
-    background-color: var(--cd-ie-primary-color--light);
-  }
+  color: var(--brand-primary--dark);
+  background-color: var(--brand-primary--light);
 }
 
 /* When it's an anchor styled as a button */
@@ -122,44 +56,18 @@ a.cd-button {
   text-decoration: none;
 }
 
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  a.cd-button {
-    display: inline-block;
-  }
-}
-
 .cd-button--outline {
-  color: var(--cd-primary-color);
-  border-color: var(--cd-primary-color);
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
   background-color: var(--cd-white);
   fill: currentColor;
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--outline {
-    color: var(--cd-ie-primary-color);
-    border-color: var(--cd-ie-primary-color);
-    background-color: var(--cd-white);
-  }
 }
 
 .cd-button--outline:hover,
 .cd-button--outline:focus {
   color: var(--cd-white);
-  border-color: var(--cd-primary-color--dark);
-  background-color: var(--cd-primary-color);
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--outline:hover,
-  .cd-button--outline:focus {
-    color: var(--cd-ie-primary-color--dark);
-    border-color: var(--cd-ie-primary-color--dark);
-    background-color: var(--cd-white);
-  }
+  border-color: var(--brand-primary--dark);
+  background-color: var(--brand-primary);
 }
 
 /* Utility classes */
@@ -271,14 +179,6 @@ a.cd-button {
   fill: currentColor;
 }
 
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--light:hover svg,
-  .cd-button--light:focus svg {
-    fill: var(--cd-ie-primary-color--dark);
-  }
-}
-
 .cd-button[disabled] {
   opacity: 0.6;
 }
@@ -320,28 +220,7 @@ a.cd-button {
 }
 
 .cd-button--danger {
-  /* --cd-highlight-red: hsl(353, 78%, 64%) */
-  --cd-primary-color-h: 353;
-  --cd-primary-color-s: 78%;
-  --cd-primary-color-l: 64%;
-  --cd-primary-color: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), var(--cd-primary-color-l));
-  /* lighten */
-  --cd-primary-color--light: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) + 10%));
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--danger {
-    background-color: var(--cd-ie-highlight-red);
-  }
-}
-
-/* For IE11 */
-@media all and (-ms-high-contrast: none) {
-  .cd-button--danger:hover,
-  .cd-button--danger:focus {
-    background-color: var(--cd-ie-highlight-red--light);
-  }
+  background-color: var(--cd-highlight-red);
 }
 
 .cd-button + .cd-button {

--- a/components/cd-button/cd-button.css
+++ b/components/cd-button/cd-button.css
@@ -27,19 +27,6 @@
   --cd-primary-color--lighter: hsl(var(--cd-primary-color-h), var(--cd-primary-color-s), calc(var(--cd-primary-color-l) + 39%));
 }
 
-/* Backgrounds */
-.cd-background--dark {
-  color: var(--cd-white);
-  background-color: var(--cd-ocha-blue);
-}
-
-.cd-background--dark,
-.cd-background--light {
-  margin-bottom: 3rem;
-  padding: 1rem;
-  text-align: center;
-}
-
 /* Default button */
 .cd-button {
   width: auto;

--- a/components/cd-button/cd-button.css
+++ b/components/cd-button/cd-button.css
@@ -39,7 +39,7 @@
 /* For buttons on dark backgrounds */
 .cd-button--light {
   color: var(--brand-primary--dark);
-  background-color: var(--brand-primary--lighter);
+  background-color: var(--brand-primary--light);
 }
 
 .cd-button--light:hover,

--- a/components/cd-button/cd-button.html
+++ b/components/cd-button/cd-button.html
@@ -1,16 +1,16 @@
 <link rel=stylesheet href="../cd-base.css" type="text/css" media=screen>
 <link rel=stylesheet href="cd-button.css" type="text/css" media=screen>
 <style>
-  .cd-background--dark {
-    color: var(--cd-white);
-    background-color: var(--cd-ocha-blue);
-  }
-
   .cd-background--dark,
   .cd-background--light {
     margin-bottom: 3rem;
     padding: 1rem;
     text-align: center;
+  }
+
+  .cd-background--dark {
+    color: var(--cd-white);
+    background-color: var(--brand-primary);
   }
 </style>
 

--- a/components/cd-button/cd-button.html
+++ b/components/cd-button/cd-button.html
@@ -190,6 +190,15 @@
 
       <p></p>
 
+      <a href="#" class="cd-button cd-button--light cd-button--bold cd-button--icon">
+        <svg class="cd-icon cd-icon--user" aria-hidden="true" focusable="false" width="16" height="16">
+          <use xlink:href="#cd-icon--user"></use>
+        </svg>
+        <span class="cd-button__text">Anchor with icon</span>
+      </a>
+
+      <p></p>
+
       <button type="button" class="cd-button cd-button--light cd-button--icon">
         <svg class="cd-icon cd-icon--user" aria-hidden="true" focusable="false" width="16" height="16">
           <use xlink:href="#cd-icon--user"></use>

--- a/components/cd-button/cd-button.html
+++ b/components/cd-button/cd-button.html
@@ -1,5 +1,18 @@
 <link rel=stylesheet href="../cd-base.css" type="text/css" media=screen>
 <link rel=stylesheet href="cd-button.css" type="text/css" media=screen>
+<style>
+  .cd-background--dark {
+    color: var(--cd-white);
+    background-color: var(--cd-ocha-blue);
+  }
+
+  .cd-background--dark,
+  .cd-background--light {
+    margin-bottom: 3rem;
+    padding: 1rem;
+    text-align: center;
+  }
+</style>
 
 <div class="cd-layout-container">
   <div class="cd-container">

--- a/components/cd-button/cd-button.html.twig
+++ b/components/cd-button/cd-button.html.twig
@@ -187,6 +187,15 @@
 
   <p></p>
 
+  <a href="#" class="cd-button cd-button--light cd-button--bold cd-button--icon">
+    <svg class="cd-icon cd-icon--user" aria-hidden="true" focusable="false" width="16" height="16">
+      <use xlink:href="#cd-icon--user"></use>
+    </svg>
+    <span class="cd-button__text">Anchor with icon</span>
+  </a>
+
+  <p></p>
+
   <button type="button" class="cd-button cd-button--light cd-button--icon">
     <svg class="cd-icon cd-icon--user" aria-hidden="true" focusable="false" width="16" height="16">
       <use xlink:href="#cd-icon--user"></use>

--- a/components/cd-button/cd-button.html.twig
+++ b/components/cd-button/cd-button.html.twig
@@ -1,4 +1,18 @@
 {{ attach_library('common_design/cd-button') }}
+<style>
+  .cd-background--dark,
+  .cd-background--light {
+    margin-bottom: 3rem;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .cd-background--dark {
+    color: var(--cd-white);
+    background-color: var(--brand-primary);
+  }
+</style>
+
 
 <div class="cd-background--light">
 

--- a/css/brand.css
+++ b/css/brand.css
@@ -105,7 +105,7 @@
    * @see common_design_subtheme/css/brand.css
    */
   --brand-primary: var(--cd-ocha-blue);
-  --brand-primary--light: var(--cd-blue--bright);
+  --brand-primary--light: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/css/brand.css
+++ b/css/brand.css
@@ -106,7 +106,6 @@
    */
   --brand-primary: var(--cd-ocha-blue);
   --brand-primary--light: var(--cd-blue--bright);
-  --brand-primary--lighter: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/css/brand.css
+++ b/css/brand.css
@@ -6,6 +6,8 @@
   --cd-blue--dark: #144372;
   /* Bright blue is one colour ramp lighter than brand blue */
   --cd-blue--bright: #82b5e9;
+  /* Brighter blue is two colour ramps higher than brand blue */
+  --cd-blue--brighter: #d4e5f7;
   --cd-highlight-red: #e56a54;
   /* This has been selected based on WCAG AAA requirements for contrast. */
   --cd-contrast-red: #e00000;
@@ -104,6 +106,7 @@
    */
   --brand-primary: var(--cd-ocha-blue);
   --brand-primary--light: var(--cd-blue--bright);
+  --brand-primary--lighter: var(--cd-blue--brighter);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);


### PR DESCRIPTION
## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)

## Description
The CD Button component now uses `--brand` colors by default, allowing them to integrate better into the CD Header where one button is guaranteed to appear (OCHA Services menu).

## Steps to reproduce the problem or Steps to test

  1. Check this branch out somewhere and use as base-theme
  2. Copy the sub-theme and enable it
  3. Choose colors in sub-theme's `css/brand.css`
  4. Review OCHA Services menu to see if button automatically uses brand colors
  
## Impact
No impact to sub-themes.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [x] I have made changes to the sub theme to reflect those in the base theme
