### PR TITLE
CD-401 fix: namespace the embeds so they do not conflict with sub theme overrides

### DIFF
--- a/templates/layout/page--404.html.twig
+++ b/templates/layout/page--404.html.twig
@@ -1,4 +1,4 @@
-{% embed 'page.html.twig' %}
+{% embed '@common_design/layout/page.html.twig' %}
 
   {% block main %}
     {# Link to skip to the main content is in html.html.twig #}

--- a/templates/layout/page--facets.html.twig
+++ b/templates/layout/page--facets.html.twig
@@ -5,7 +5,7 @@
 ]
 %}
 
-{% embed 'page.html.twig' %}
+{% embed '@common_design/layout/page.html.twig' %}
 
   {% block main %}
     {# Link to skip to the main content is in html.html.twig #}


### PR DESCRIPTION
Refs: CD-401

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
-  Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Since the template embed was not namespaced, it conflicts with any `page.html.twig` override files in the sub theme

## Motivation and Context
This means the `page--facets.html.twig` main block was not being applied, thus we were not able to see the facets region, which is specific to the facet page template override.
<!--- If it fixes an open issue, please link to the issue here. -->

## Expected behavior
<!--- Describe what should happen. -->
Even when there is a sub theme enabled, the facets region from `page--facets.html.twig` should display.

## Actual behavior
<!--- Describe what actually happens. -->
Currently, when the sub theme is enabled, https://commondesign.test/facets does not show the facets region

## Impact
This is unlikely to negatively affect any implementations, but is used for the CD Demo site https://web.brand.unocha.org/facets

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] I have run local tests and the tests pass.
- [ ] I have linted my code locally.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
