### PR TITLE
chore(release): add release-please GitHub Action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'


### PR DESCRIPTION
## Types of changes

- [x] Maintenance chore

## Description

We are currently using `standard-version` to automate CHANGELOG during releases. It's deprecated now, and they pointed to Google's `release-please` as a substitute. This branch contains the GitHub Action with default config. I will try it out by merging to `main` and seeing what the outcome is. If we don't like it, we can delete the releases until it does what we want. 

Once it's behaving nicely, I'll remove `standard-version` and update the docs to match the finalized process I arrive at while doing this work.

## Motivation and Context
Deprecated dependency.

## Steps to reproduce the problem or Steps to test

  1. Merge `develop` into `main`
  1. Observe what the GitHub Action does.
  
  
## Impact
This change has absolutely zero effect on the Common Design codebase. It's a change in our release process.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
