### PR TITLE
fix: avoid abbreviations in visually-hidden logo text

### DIFF
--- a/templates/cd/cd-footer/cd-mandate.html.twig
+++ b/templates/cd/cd-footer/cd-mandate.html.twig
@@ -2,7 +2,7 @@
   <div class="cd-mandate">
     <span class="cd-mandate__heading">{{ 'Service provided by'|t }}</span>
     <span class="cd-mandate__logo">
-      <span class="visually-hidden">{{ 'UNOCHA'|t }}</span>
+      <span class="visually-hidden">{{ 'United Nations Office for the Coordination of Humanitarian Affairs'|t }}</span>
     </span>
     <span class="cd-mandate__text">
       {{ 'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.'|t }}


### PR DESCRIPTION
Refs: CD-413

## Types of changes
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
We used `UNOCHA` in a visually hidden span representing the footer logo. I spelled out the full org name.

## Motivation and Context
a11y / seo

## Steps to reproduce the problem or Steps to test

  1. Inspect OCHA logo in footer and hunt around for the visually hidden name
 
  
## Impact
There is no impact or remediation necessary for any website. If they overrode the template in a subtheme, this text won't change automatically. But it's basically a cosmetic change.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
