### PR TITLE
refactor: better account menu consistency across sites

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -551,7 +551,7 @@ function common_design_preprocess_block__language_block(&$vars) {
  *
  * My account
  *   Edit my account
- *   ... (potential other meny items)
+ *   ... (potential other menu items)
  *   Log out
  */
 function common_design_preprocess_menu__account(&$variables) {

--- a/common_design.theme
+++ b/common_design.theme
@@ -8,6 +8,8 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Template\Attribute;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_form_system_theme_settings_alter().
@@ -339,10 +341,12 @@ function common_design_theme_suggestions_form_alter(array &$suggestions, array $
   $suggestions[] = 'form__' . $variables['element']['#form_id'];
 }
 
+/**
+ * Impements hook_theme_suggestions_form_element_alter().
+ */
 function common_design_theme_suggestions_form_element_alter(array &$suggestions, array $variables, $hook) {
   $suggestions[] = $hook . '__' . $variables['element']['#type'];
 }
-
 
 /**
  * Implements hook_form_alter().
@@ -542,21 +546,98 @@ function common_design_preprocess_block__language_block(&$vars) {
 
 /**
  * Implements hook_preprocess_menu().
+ *
+ * Ensure we have a user menu hierarchy in the form:
+ *
+ * My account
+ *   Edit my account
+ *   ... (potential other meny items)
+ *   Log out
  */
-function common_design_preprocess_menu(&$variables, $hook) {
-  if ($hook == 'menu__account') {
-    // Rename 'My account'.
-    if (isset($variables['items']['user.page'])) {
-      $variables['items']['user.page']['title'] = t('Edit my account');
+function common_design_preprocess_menu__account(&$variables) {
+  $items = &$variables['items'] ?? [];
+
+  $base_child_menu_item = [
+    'is_expanded' => FALSE,
+    'is_collapsed' => FALSE,
+    'in_active_trail' => FALSE,
+    'attributes' => new Attribute(),
+    'below' => [],
+  ];
+
+  // Find the "My account" menu item. It may be the default system menu item
+  // from the core user module or a custom one added as per release instructions
+  // of the CD 7.4 version.
+  foreach ($items as &$item) {
+    if (isset($item['url']) && $item['url']->isRouted() && $item['url']->getRouteName() === 'user.page') {
+      $account_menu_item = &$item;
+      break;
+    }
+  }
+
+  // If there is a menu account, add a child link to the user edit form (or
+  // user page for Drupal < 9.5) and a child link to log out; and consolidate
+  // the labels.
+  if (isset($account_menu_item)) {
+    $children = $account_menu_item['below'] ?? [];
+
+    // Retrieve or create a link to the user page. This is mostly for backward
+    // compatibility with the CD 7.4.
+    if (isset($children['user.page'])) {
+      $user_edit_menu_item = $children['user.page'];
+      unset($children['user.page']);
     }
     else {
-      // Might be nested.
-      foreach ($variables['items'] as &$parent) {
-        if (isset($parent['below']['user.page'])) {
-          $parent['below']['user.page']['title'] = t('Edit my account');
-        }
+      $user_edit_menu_item = $base_child_menu_item;
+    }
+
+    // For Drupal 9.5+, we redirect to the user edit form.
+    if (!empty(\Drupal::service('router')->getRouteCollection()->get('user.edit'))) {
+      $user_edit_menu_item['url'] = Url::fromRoute('user.edit');
+    }
+    elseif (!isset($user_edit_menu_item['url'])) {
+      $user_edit_menu_item['url'] = Url::fromRoute('user.page');
+    }
+
+    // Ensure the title is consistent across sites using the CD.
+    $user_edit_menu_item['title'] = t('Edit my account');
+
+    // Add it as the first link.
+    $children = ['user.page' => $user_edit_menu_item] + $children;
+
+    // Retrieve any existing logout link. This is mostly for backward
+    // compatibility with the CD 7.4 and prevents multiple logout links.
+    foreach ($children as $key => $child) {
+      if (isset($child['url']) && $child['url']->isRouted() && $child['url']->getRouteName() === 'user.logout') {
+        $logout_menu_item = $child;
+        unset($children[$key]);
       }
     }
+
+    // Use the top logout link if it exists.
+    if (isset($items['user.logout'])) {
+      $logout_menu_item = $items['user.logout'];
+      unset($items['user.logout']);
+    }
+    // Otherwise create a new one if we didn't find one earlier.
+    elseif (!isset($logout_menu_item)) {
+      $logout_menu_item = $base_child_menu_item + [
+        'url' => Url::fromRoute('user.logout'),
+      ];
+    }
+
+    // Ensure the title is consistent across sites using the CD.
+    $logout_menu_item['title'] = t('Log out');
+
+    // Add the link at the bottom.
+    $children['user.logout'] = $logout_menu_item;
+
+    // Mark the menu item as expanded so it's converted to a button.
+    $account_menu_item['is_expanded'] = TRUE;
+    $account_menu_item['below'] = $children;
+
+    // Ensure the title is consistent across sites using the CD.
+    $account_menu_item['title'] = t('My account');
   }
 }
 
@@ -826,7 +907,6 @@ function common_design_form_user_form_alter(array &$form, FormStateInterface $fo
   common_design_add_entity_edit_form_theme($form, $form_state);
 }
 
-
 /**
  * Implemenents hook_preprocess_fieldset().
  */
@@ -849,4 +929,3 @@ function common_design_preprocess_datetime_wrapper(&$variables) {
     $variables['title_attributes']['class'][] = 'visually-hidden';
   }
 }
-


### PR DESCRIPTION
Refs: CD-254

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
<!--- Describe your changes in detail -->

This is an attempt at simplifying the changes to the user menu introduced in the 7.4.0 version, requiring less to no changes for sites upgrading to that version while ensuring a consistent user menu across sites in the form:

```
My account
    Edit my account
    ... (other actions)
    Log out
````

With the changes in that PR, the `Edit my account` and `Log out` are automatically added as first and last links under the `My account` menu item.

<img width="241" alt="Screen Shot 2022-12-23 at 15 43 50" src="https://user-images.githubusercontent.com/696348/209286124-892e7d25-5e6e-4880-945d-bdcce3b77679.png">

That means, there is no need to change the default Drupal user menu account (that contains the `My account` and `Log out` menu items provided by the `user` module). 

Additional menu items can be added as children of the `My account` menu item and will appear between the `Edit my account` and `Log out`. Ex:

<img width="247" alt="Screen Shot 2022-12-23 at 15 45 49" src="https://user-images.githubusercontent.com/696348/209286103-1149e221-1637-4f2a-bfad-bbfce91de3e4.png">

**Note:** For sites using Drupal 9.5+, the `Edit my account` link actually points at the used edit form since a new `/user/edit` route was introduced in 9.5: https://www.drupal.org/node/3313603; while it points to the user page (`/user`) like in the CD 7.4.0 for Drupal < 9.5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The motivation behind this PR is that the CD 7.4 introduces changes to the user menu that require manual intervention after a deployment to set up the user menu account correctly.

In addition the CD 7.4 only partially enforces consistency by only forcing the "Edit my account" label and relies on people updating the user menu to properly set the "My account" and "Log out" link labels.
  
## Impact

The code in this PR in backward compatible with the changes to the user menu instructed to be made in the CD 7.4. It should be transparent for sites that already upgraded to 7.4 and changed their user menu. Though they may want to revert the changes made for 7.4 to have something cleaner.

For sites upgrading from a previous version of the CD, the transition to the new user account menu pattern should be transparent **unless** they were already doing something to this menu. Even so, this should have almost no impact.

**CD 7.4 instructions**

This PR basically cancels the instructions from the 7.4.0 release regarding the user menu as for sites that just had a "My account" link in the header (probably most), there is nothing to do when upgrading.

The new instructions should say that the "Edit my account" and "Log out" child links are added automatically and that to add additional actions in between, one can edit the user menu and add links under "My account" and ensure its "expanded" checkbox is checked.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] I have run local tests and the tests pass.
- [x] I have linted my code locally.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
