### PR TITLE
fix: remove float variant from ToC and increase columns

### DIFF
--- a/components/cd-toc/README.md
+++ b/components/cd-toc/README.md
@@ -1,22 +1,14 @@
 # Table of contents
 
 ## Purpose and Usage
-A list of links to page headings for onpage navigation.
-
-Default behaviour is to grow to fit available content. When floated, the width
-is restricted.
+A list of links to page headings for on-page navigation. Default behaviour is to grow to fit available content.
 
 ## Caveats
-This is currently using cd-utilities for the float rules.
 Due to the use of the CSS counters, the list items do not indent when wrapped.
 
 ### Variants
 
-```
-.cd-toc--float-left
-.cd-toc--float-right
-
-// On the ol element.
+```css
+/* On the ol element. */
 .cd-toc__list--roman
-
 ```

--- a/components/cd-toc/cd-toc.css
+++ b/components/cd-toc/cd-toc.css
@@ -2,11 +2,14 @@
  * CD Table of Contents (ToC)
  */
 
+:root {
+  --cd-toc-cols: 1;
+}
+
 .cd-toc {
   position: relative;
   z-index: 1;
-  display: inline-block;
-  min-width: 16rem;
+  width: 100%;
   margin-bottom: 1rem;
   padding: 1rem;
   background-color: var(--brand-grey);
@@ -16,6 +19,7 @@
 .cd-toc__list ol {
   margin-bottom: 0;
   padding: 0;
+  columns: var(--cd-toc-cols, 1);
 }
 
 .cd-toc ol {
@@ -57,30 +61,19 @@
 }
 
 @media (min-width: 576px) {
-  div[class*="cd-toc--float"] {
-    display: block;
-    max-width: 16rem;
-  }
-
-  .cd-toc--float-left {
-    margin: 0 1rem 1rem 0;
-  }
-
-  .cd-toc--float-right {
-    margin: 0 0 1rem 1rem;
-  }
-
-  [dir="rtl"] .cd-toc--float-left {
-    margin: 0 0 1rem 1rem;
-  }
-
-  [dir="rtl"] .cd-toc--float-right {
-    margin: 0 1rem 1rem 0;
+  .cd-toc__list {
+    --cd-toc-cols: 2;
   }
 }
 
-@media (min-width: 1024px) {
-  div[class*="cd-toc--float"] {
-    max-width: 24rem;
+@media (min-width: 820px) {
+  .cd-toc__list {
+    --cd-toc-cols: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .cd-toc__list {
+    --cd-toc-cols: 4;
   }
 }


### PR DESCRIPTION
Refs: CD-412

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Removed the float option (if you want a column for it, use a layout). It now expands to fill space by breaking the ToC into columns. For CD Demo, the items are an ordered list so the numbers make it a bit easier to follow. People can always override this behavior if they find it undesirable:

```css
@media (min-width: 576px) {
  .cd-toc__list {
    --cd-toc-cols: 1; /* override */
  }
}
```
  
## Impact
Sites using the float-related classes will no longer see the component floating.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.

