### PR TITLE
[CD-450] CD Spacious should not affect tabs

### DIFF
--- a/common_design_subtheme/package-lock.json
+++ b/common_design_subtheme/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design-subtheme",
-  "version": "7.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/common_design_subtheme/package.json
+++ b/common_design_subtheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design-subtheme",
-  "version": "7.0.0",
+  "version": "8.0.1",
   "description": "OCHA Common Design sub theme for Drupal 9+",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",

--- a/components/cd/cd-resets/cd-typography.css
+++ b/components/cd/cd-resets/cd-typography.css
@@ -143,8 +143,8 @@ img {
 
 .cd-content--spacious dl dt,
 .cd-content--spacious dl dd,
-.cd-content--spacious ol li + li,
-.cd-content--spacious ul li + li {
+.cd-content--spacious ol:not([role=list]) li + li,
+.cd-content--spacious ul:not([role=list], .tabs) li + li {
   margin-top: calc(var(--cd-font-size--ref) / 2);
 }
 


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)

## Description
We noticed that the tabs got nudged around using the CD Spacious mode. This fixes it.

## Steps to reproduce the problem or Steps to test

  1. Log in so you get tabs somewhere
  1. Load a page which applies `.cd-content--spacious` high enough in the DOM to affect the tabs
  1. Load this branch and confirm the tabs look normal
  
## Impact
No impact.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
