### PR TITLE
fix: revert the disruptive display:block on img tags

### DIFF
--- a/components/cd/cd-resets/cd-typography.css
+++ b/components/cd/cd-resets/cd-typography.css
@@ -82,7 +82,6 @@ u {
 }
 
 img {
-  display: block;
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
Refs: CD-459

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Bug fix for an overreaching breaking change I made to `<img>` in v8.0.0

## Impact
Behavior of `<img>` is reverted to pre-8.0.0

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
