### PR TITLE
[CD-454] :focus-visible styles

### DIFF
--- a/components/cd/cd-footer/cd-footer-copyright.css
+++ b/components/cd/cd-footer/cd-footer-copyright.css
@@ -23,10 +23,6 @@
   }
 }
 
-.cd-footer-copyright__text a:focus {
-  outline-offset: 1px;
-}
-
 .cd-footer-copyright svg {
   flex: 0 0 38px;
   width: 38px;
@@ -35,22 +31,18 @@
   fill: var(--cd-white);
 }
 
-@media (min-width: 1024px) {
-  .cd-footer-copyright svg {
-    margin: 0 0 0 20px;
-  }
-
-  [dir=rtl] .cd-footer-copyright svg {
-    margin: 0 20px 0 0;
-  }
-}
-
 /* To override `.cd-footer a` we must use tag in selector */
 a.cd-footer-copyright__link:hover {
   transition: opacity 0.1666s ease-in-out;
   opacity: 0.8;
 }
 
-a.cd-footer-copyright__link:focus {
-  outline-offset: 0;
+/* To override `.cd-footer a` we must use tag in selector */
+a.cd-footer-copyright__link:focus-visible {
+  outline-offset: 5px;
+}
+
+/* To override `.cd-footer a` we must use tag in selector */
+.cd-footer-copyright__text a:focus {
+  outline-offset: 1px;
 }

--- a/components/cd/cd-footer/cd-footer-social.css
+++ b/components/cd/cd-footer/cd-footer-social.css
@@ -23,6 +23,7 @@
 a.cd-footer-social__link {
   display: inline-block;
   border: 0 none;
+  line-height: 0; /* cosmetic improvement to focus style */
 }
 
 a.cd-footer-social__link svg {

--- a/components/cd/cd-footer/cd-footer.css
+++ b/components/cd/cd-footer/cd-footer.css
@@ -48,18 +48,18 @@
 }
 
 .cd-footer a:hover,
-.cd-footer a:focus {
+.cd-footer a:focus-visible {
   text-decoration: underline;
   color: var(--cd-white);
 }
 
 .cd-footer a.cd-button:hover,
-.cd-footer a.cd-button:focus {
+.cd-footer a.cd-button:focus-visible {
   color: initial;
 }
 
-.cd-footer a:focus {
-  outline: 3px solid var(--brand-primary--light);
+.cd-footer a:focus-visible {
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: 8px;
 }
 

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -112,24 +112,6 @@
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.3);
 }
 
-/* Triangle on toggle when active. */
-.cd-global-header button[aria-expanded="true"] {
-  position: relative;
-}
-
-.cd-global-header button[aria-expanded="true"]::before {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 0;
-  height: 0;
-  margin-left: -6px;
-  content: "";
-  border-width: 0 6px 6px;
-  border-style: solid;
-  border-color: transparent transparent var(--brand-primary);
-}
-
 button[aria-expanded] .cd-icon--arrow-down {
   fill: var(--cd-white);
   width: 9px;

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -76,11 +76,6 @@
   color: var(--cd-white);
 }
 
-.cd-global-header .menu > li li a,
-.cd-global-header .menu > li li button {
-  padding: 0 !important;
-}
-
 /* Last block in Global Header should have its dropdown right-aligned on LTR */
 .cd-global-header .cd-global-header__user-menu:last-child .cd-global-header__dropdown {
   right: 0;

--- a/components/cd/cd-header/cd-header.css
+++ b/components/cd/cd-header/cd-header.css
@@ -41,7 +41,7 @@
 .cd-header button:focus-visible,
 .cd-header a:focus-visible {
   position: relative;
+  z-index: calc(var(--cd-z-dropdown) + 1);
   outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: calc(0px - var(--cd-outline-size));
-  z-index: calc(var(--cd-z-dropdown) + 1);
 }

--- a/components/cd/cd-header/cd-header.css
+++ b/components/cd/cd-header/cd-header.css
@@ -25,7 +25,23 @@
   background-color: transparent;
 }
 
-/* We want uniform focus styles on the whole Header */
-.cd-header button:focus {
-  outline: 3px solid var(--brand-primary--light);
+/**
+ * CD Header focus styles
+ *
+ * The focus styles should be consistent across the entire header. Using the
+ * focus-visible selector means that direct clicks won't cause the outline to
+ * be visible, but non-pointer nav such as keyboard will still show it.
+ */
+.cd-header a:hover,
+.cd-header a:focus-visible {
+  text-decoration: underline;
+  color: var(--cd-white);
+}
+
+.cd-header button:focus-visible,
+.cd-header a:focus-visible {
+  position: relative;
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
+  outline-offset: calc(0px - var(--cd-outline-size));
+  z-index: calc(var(--cd-z-dropdown) + 1);
 }

--- a/components/cd/cd-header/cd-language-switcher.css
+++ b/components/cd/cd-header/cd-language-switcher.css
@@ -19,7 +19,7 @@
 }
 
 .cd-language-switcher__btn:focus {
-  outline: 3px solid var(--brand-primary--light);
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
 }
 
 @media (min-width: 768px) {
@@ -57,10 +57,6 @@
 .cd-language-switcher__dropdown li a:hover,
 .cd-language-switcher__dropdown li a:focus {
   text-decoration: underline;
-}
-
-.cd-language-switcher__dropdown li a:focus {
-  outline: 3px solid var(--brand-primary--light);
 }
 
 .cd-language-switcher__dropdown li a.is-active {

--- a/components/cd/cd-header/cd-logo.css
+++ b/components/cd/cd-header/cd-logo.css
@@ -18,8 +18,14 @@
   background: linear-gradient(transparent, transparent), url("../../../img/logos/ocha-logo-blue.svg") center no-repeat;
 }
 
-.cd-site-logo:focus {
-  outline: 3px solid var(--brand-primary--light);
+/**
+ * Override default focus z-index. If the default applies, the logo might appear
+ * on top of the opened OCHA Services menu. Alternative fix is ticketed:
+ *
+ * @see https://humanitarian.atlassian.net/browse/CD-173
+ */
+.cd-header a.cd-site-logo:focus-visible {
+  z-index: var(--cd-z-default);
 }
 
 /* Larger format logo once space permits */

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -10,11 +10,15 @@
   display: flex;
   align-items: center;
   height: var(--cd-global-header-height);
-  padding: 0;
+  padding: 0 var(--cd-outline-size);
   transition: background 0.3s ease;
   color: var(--cd-white);
   background: transparent;
   font-size: var(--cd-font-size--tiny);
+}
+
+.cd-ocha__btn:focus-visible {
+  outline-offset: calc(0px - var(--cd-outline-size));
 }
 
 .cd-ocha__btn .cd-icon--arrow-down {
@@ -70,16 +74,10 @@
   color: var(--cd-white);
 }
 
-.cd-ocha-dropdown__link a:hover,
-.cd-ocha-dropdown__link a:focus {
-  text-decoration: underline;
-  color: var(--cd-white);
-}
-
-.cd-ocha-dropdown__link a:focus {
-  outline: 3px solid var(--brand-primary--light);
+.cd-ocha-dropdown__link a:focus-visible {
   outline-offset: 8px;
 }
+
 
 /**
  * Selector needs to override CD Button because of source order.

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -134,6 +134,7 @@
 
   .cd-ocha-dropdown__inner {
     flex-flow: row nowrap;
+    align-items: flex-end;
     margin: 0 auto;
     padding: 0 var(--cd-container-padding-tablet);
   }
@@ -143,11 +144,9 @@
     margin-bottom: 0;
   }
 
-  .cd-ocha-dropdown__see-all {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
+  /* it's a cd-button-styled <a> so it has focus styles already */
+  .cd-header a.cd-ocha-dropdown__see-all:focus-visible {
+    outline: none;
   }
 }
 

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -78,7 +78,6 @@
   outline-offset: 8px;
 }
 
-
 /**
  * Selector needs to override CD Button because of source order.
  */

--- a/components/cd/cd-header/cd-search.css
+++ b/components/cd/cd-header/cd-search.css
@@ -111,6 +111,15 @@
   background: var(--cd-white);
 }
 
+/* If a person uses keyboard nav to re-focus the search button, then we should
+show the outline, overriding the default focus styles for pointer events. */
+.cd-search__btn[aria-expanded=true]:focus-visible {
+  position: relative;
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
+  outline-offset: calc(0px - var(--cd-outline-size));
+  z-index: calc(var(--cd-z-dropdown) + 1);
+}
+
 .cd-search__btn-label {
   text-transform: uppercase;
   font-size: var(--cd-font-size--tiny);

--- a/components/cd/cd-header/cd-search.css
+++ b/components/cd/cd-header/cd-search.css
@@ -115,9 +115,9 @@
 show the outline, overriding the default focus styles for pointer events. */
 .cd-search__btn[aria-expanded=true]:focus-visible {
   position: relative;
+  z-index: calc(var(--cd-z-dropdown) + 1);
   outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: calc(0px - var(--cd-outline-size));
-  z-index: calc(var(--cd-z-dropdown) + 1);
 }
 
 .cd-search__btn-label {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -86,8 +86,8 @@
 }
 
 [data-cd-menu-level="1"] {
-  padding-inline: .5rem;
-  padding-block: .5rem;
+  padding-inline: 0.5rem;
+  padding-block: 0.5rem;
 }
 
 .cd-user-menu > .menu-item:last-child > ul.menu {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -61,13 +61,6 @@
   text-decoration: underline;
 }
 
-.cd-user-menu__item:focus,
-.cd-user-menu li a:focus,
-.cd-user-menu li button:focus {
-  outline: 3px solid var(--brand-primary--light);
-  outline-offset: -2px;
-}
-
 .cd-user-menu__item .cd-user-menu__btn-label,
 .cd-user-menu li a .cd-user-menu__btn-label,
 .cd-user-menu li button .cd-user-menu__btn-label {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -82,7 +82,12 @@
 .cd-user-menu__dropdown {
   min-width: 125px;
   margin: 0;
-  padding: 12px 24px;
+  padding: 0;
+}
+
+[data-cd-menu-level="1"] {
+  padding-inline: .5rem;
+  padding-block: .5rem;
 }
 
 .cd-user-menu > .menu-item:last-child > ul.menu {

--- a/css/brand.css
+++ b/css/brand.css
@@ -116,6 +116,11 @@
   --cd-z-skip-link: 1000;
 
   /**
+   * Accessibility-related properties
+   */
+  --cd-outline-size: 3px;
+
+  /**
    * Site-specific brand defaults
    *
    * You can override these defaults in the SUB-THEME. We provide default values

--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -40,7 +40,7 @@
 
     {% set parent_id = attributes.id ?? ('cd-user-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes) }}>
+    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
 
     {% for item in items %}
       {%

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -40,7 +40,7 @@
 
     {% set parent_id = attributes.id ?? ('cd-help-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes) }}>
+    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
 
     {% for item in items %}
       {%


### PR DESCRIPTION
# CD-454, CD-357

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Adopt `:focus-visible` styles in Header/Footer

## Motivation and Context
The focus styles are less obtrusive for mouse users, which will hopefully mean that teams stop overriding them with harmful resets that remove the styles entirely, causing accessibility issues with the modified websites.

Additionally, keyboard navigation is more attractive and hopefully that translates to a UX improvement.

The Search dropdown also uses the same `:focus-visible` styles so that it shows focus during keyboard nav. This issue was previously ticketed in CD-357.

## Expected behavior
Mouse/touch users will no longer trigger focus styles when toggling dropdowns. The focus styles have been consolidated and are using CSS Vars so that they can be restyled in a unified fashion (for example when picking branding colors at the beginning of a project, or if we ever offered a high-contrast mode).

## Steps to reproduce the problem or Steps to test

  1. Interact with each UI widget in the Global Header via mouse
  1. Interact with each UI widget in the Global Header via keyboard nav  

See ticket for videos of before/after.

## Impact
There are no steps to upgrade unless someone has modified the CD itself within their project-specific files.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
