### PR TITLE
[CD-453] RTL refactors

### DIFF
--- a/components/cd/cd-footer/cd-footer-copyright.css
+++ b/components/cd/cd-footer/cd-footer-copyright.css
@@ -4,7 +4,8 @@
 .cd-footer-copyright {
   display: flex;
   align-items: center;
-  max-width: 350px;
+  gap: 20px;
+  max-width: 390px;
   margin: 0 auto;
 }
 
@@ -21,6 +22,10 @@
   [dir=rtl] .cd-footer-copyright {
     text-align: left;
   }
+}
+
+.cd-footer-copyright__link {
+  line-height: 0; /* ensures flex centers it correctly */
 }
 
 .cd-footer-copyright svg {

--- a/components/cd/cd-footer/cd-footer-copyright.css
+++ b/components/cd/cd-footer/cd-footer-copyright.css
@@ -16,11 +16,7 @@
     justify-content: flex-end;
     margin: 0;
     margin-top: 34px; /* Align with provide-by main text. */
-    text-align: right;
-  }
-
-  [dir=rtl] .cd-footer-copyright {
-    text-align: left;
+    text-align: end;
   }
 }
 

--- a/components/cd/cd-footer/cd-footer-copyright.css
+++ b/components/cd/cd-footer/cd-footer-copyright.css
@@ -23,10 +23,6 @@
   }
 }
 
-.cd-footer-copyright__text a:focus {
-  outline-offset: 1px;
-}
-
 .cd-footer-copyright svg {
   flex: 0 0 38px;
   width: 38px;
@@ -35,22 +31,18 @@
   fill: var(--cd-white);
 }
 
-@media (min-width: 1024px) {
-  .cd-footer-copyright svg {
-    margin: 0 0 0 20px;
-  }
-
-  [dir=rtl] .cd-footer-copyright svg {
-    margin: 0 20px 0 0;
-  }
-}
-
 /* To override `.cd-footer a` we must use tag in selector */
 a.cd-footer-copyright__link:hover {
   transition: opacity 0.1666s ease-in-out;
   opacity: 0.8;
 }
 
-a.cd-footer-copyright__link:focus {
-  outline-offset: 0;
+/* To override `.cd-footer a` we must use tag in selector */
+a.cd-footer-copyright__link:focus-visible {
+  outline-offset: 5px;
+}
+
+/* To override `.cd-footer a` we must use tag in selector */
+.cd-footer-copyright__text a:focus {
+  outline-offset: 1px;
 }

--- a/components/cd/cd-footer/cd-footer-mandate.css
+++ b/components/cd/cd-footer/cd-footer-mandate.css
@@ -3,28 +3,21 @@
  */
 .cd-mandate {
   width: 100%;
-}
-
-.cd-mandate__logo {
-  display: block;
-  width: 149px;
-  height: 37px;
-  margin: 0 auto 16px;
-  background: url("../../../img/logos/ocha-lockup.svg") 0 center no-repeat;
-}
-
-[dir=rtl] .cd-mandate__logo {
-  background-position: 100% 0;
-}
-
-.no-svg .cd-mandate__logo {
-  background: url("../../../img/logos/ocha-lockup@149x37.png") 0 center no-repeat;
+  text-align: center;
 }
 
 .cd-mandate__heading {
   display: block;
   margin-bottom: 16px;
   padding: 0 var(--cd-container-padding);
+}
+
+.cd-mandate__logo {
+  display: block;
+  width: 149px;
+  height: 37px;
+  margin-inline: auto;
+  margin-block-end: 1rem;
 }
 
 .cd-mandate__text {
@@ -36,40 +29,31 @@
 
 @media (min-width: 1024px) {
   .cd-mandate {
+    display: flex;
+    flex-flow: row wrap;
     margin: 0;
-  }
-
-  .cd-mandate__logo {
-    float: left;
-    width: calc(149px + var(--cd-container-padding));
-    margin: -4px var(--cd-container-padding) 0 auto;
-    border-inline-end: 1px solid var(--brand-grey);
-  }
-
-  [dir=rtl] .cd-mandate__logo {
-    float: right;
-    margin: -4px auto 0 var(--cd-container-padding);
+    column-gap: var(--cd-container-padding);
   }
 
   .cd-mandate__heading {
+    flex: 1 0 100%;
     padding: 0;
-    text-align: left;
+    text-align: initial;
   }
 
-  [dir=rtl] .cd-mandate__heading {
-    text-align: right;
+  .cd-mandate__logo {
+    flex: 0 0 calc(149px + var(--cd-container-padding));
+    height: auto;
+    margin: 0;
+    padding-inline-end: var(--cd-container-padding);
+    border-inline-end: 1px solid var(--brand-grey);
   }
 
   .cd-mandate__text {
-    max-width: 100%;
+    flex: 1 1 0;
     margin: 0;
     padding: 0;
-    padding-inline-start: 173px; /* accomodate logo */
     padding-inline-end: var(--cd-container-padding-xlarge);
-    text-align: left;
-  }
-
-  [dir=rtl] .cd-mandate__text {
-    text-align: right;
+    text-align: initial;
   }
 }

--- a/components/cd/cd-footer/cd-footer-social.css
+++ b/components/cd/cd-footer/cd-footer-social.css
@@ -23,6 +23,7 @@
 a.cd-footer-social__link {
   display: inline-block;
   border: 0 none;
+  line-height: 0; /* cosmetic improvement to focus style */
 }
 
 a.cd-footer-social__link svg {

--- a/components/cd/cd-footer/cd-footer.css
+++ b/components/cd/cd-footer/cd-footer.css
@@ -109,16 +109,12 @@
 @media (min-width: 1024px) {
   .cd-footer__section--menu {
     flex: 1 0 70%;
-    text-align: left;
-  }
-
-  [dir=rtl] .cd-footer__section--menu {
-    text-align: right;
+    text-align: start;
   }
 
   .cd-footer__section--social {
     flex: 0 1 30%;
-    text-align: right;
+    text-align: end;
   }
 
   .cd-footer__section--mandate {

--- a/components/cd/cd-footer/cd-footer.css
+++ b/components/cd/cd-footer/cd-footer.css
@@ -48,18 +48,18 @@
 }
 
 .cd-footer a:hover,
-.cd-footer a:focus {
+.cd-footer a:focus-visible {
   text-decoration: underline;
   color: var(--cd-white);
 }
 
 .cd-footer a.cd-button:hover,
-.cd-footer a.cd-button:focus {
+.cd-footer a.cd-button:focus-visible {
   color: initial;
 }
 
-.cd-footer a:focus {
-  outline: 3px solid var(--brand-primary--light);
+.cd-footer a:focus-visible {
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: 8px;
 }
 

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -112,24 +112,6 @@
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.3);
 }
 
-/* Triangle on toggle when active. */
-.cd-global-header button[aria-expanded="true"] {
-  position: relative;
-}
-
-.cd-global-header button[aria-expanded="true"]::before {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 0;
-  height: 0;
-  margin-left: -6px;
-  content: "";
-  border-width: 0 6px 6px;
-  border-style: solid;
-  border-color: transparent transparent var(--brand-primary);
-}
-
 button[aria-expanded] .cd-icon--arrow-down {
   fill: var(--cd-white);
   width: 9px;

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -36,7 +36,6 @@
   margin-inline-end: -2px;
 }
 
-
 /*
  * If there are multiple Global Header actions, separate them with pipe-looking
  * visuals. To control the width of the pipes, set horizontal gap accordingly.

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -31,15 +31,11 @@
   display: flex;
   flex-flow: row nowrap;
   gap: 0;
+
+  /* Visually align button contents with main nav */
+  margin-inline-end: -2px;
 }
 
-/* Visually align button contents with main nav */
-[dir="ltr"] .cd-global-header__actions {
-  right: -2px;
-}
-[dir="rtl"] .cd-global-header__actions {
-  left: -2px;
-}
 
 /*
  * If there are multiple Global Header actions, separate them with pipe-looking
@@ -77,7 +73,7 @@
 }
 
 /* Last block in Global Header should have its dropdown right-aligned on LTR */
-.cd-global-header .cd-global-header__user-menu:last-child .cd-global-header__dropdown {
+[dir="ltr"] .cd-global-header .cd-global-header__user-menu:last-child .cd-global-header__dropdown {
   right: 0;
   left: initial;
 }

--- a/components/cd/cd-header/cd-global-header.css
+++ b/components/cd/cd-header/cd-global-header.css
@@ -76,11 +76,6 @@
   color: var(--cd-white);
 }
 
-.cd-global-header .menu > li li a,
-.cd-global-header .menu > li li button {
-  padding: 0 !important;
-}
-
 /* Last block in Global Header should have its dropdown right-aligned on LTR */
 .cd-global-header .cd-global-header__user-menu:last-child .cd-global-header__dropdown {
   right: 0;

--- a/components/cd/cd-header/cd-header.css
+++ b/components/cd/cd-header/cd-header.css
@@ -41,7 +41,7 @@
 .cd-header button:focus-visible,
 .cd-header a:focus-visible {
   position: relative;
+  z-index: calc(var(--cd-z-dropdown) + 1);
   outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: calc(0px - var(--cd-outline-size));
-  z-index: calc(var(--cd-z-dropdown) + 1);
 }

--- a/components/cd/cd-header/cd-header.css
+++ b/components/cd/cd-header/cd-header.css
@@ -25,7 +25,23 @@
   background-color: transparent;
 }
 
-/* We want uniform focus styles on the whole Header */
-.cd-header button:focus {
-  outline: 3px solid var(--brand-primary--light);
+/**
+ * CD Header focus styles
+ *
+ * The focus styles should be consistent across the entire header. Using the
+ * focus-visible selector means that direct clicks won't cause the outline to
+ * be visible, but non-pointer nav such as keyboard will still show it.
+ */
+.cd-header a:hover,
+.cd-header a:focus-visible {
+  text-decoration: underline;
+  color: var(--cd-white);
+}
+
+.cd-header button:focus-visible,
+.cd-header a:focus-visible {
+  position: relative;
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
+  outline-offset: calc(0px - var(--cd-outline-size));
+  z-index: calc(var(--cd-z-dropdown) + 1);
 }

--- a/components/cd/cd-header/cd-language-switcher.css
+++ b/components/cd/cd-header/cd-language-switcher.css
@@ -19,7 +19,7 @@
 }
 
 .cd-language-switcher__btn:focus {
-  outline: 3px solid var(--brand-primary--light);
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
 }
 
 @media (min-width: 768px) {
@@ -57,10 +57,6 @@
 .cd-language-switcher__dropdown li a:hover,
 .cd-language-switcher__dropdown li a:focus {
   text-decoration: underline;
-}
-
-.cd-language-switcher__dropdown li a:focus {
-  outline: 3px solid var(--brand-primary--light);
 }
 
 .cd-language-switcher__dropdown li a.is-active {

--- a/components/cd/cd-header/cd-logo.css
+++ b/components/cd/cd-header/cd-logo.css
@@ -18,8 +18,14 @@
   background: linear-gradient(transparent, transparent), url("../../../img/logos/ocha-logo-blue.svg") center no-repeat;
 }
 
-.cd-site-logo:focus {
-  outline: 3px solid var(--brand-primary--light);
+/**
+ * Override default focus z-index. If the default applies, the logo might appear
+ * on top of the opened OCHA Services menu. Alternative fix is ticketed:
+ *
+ * @see https://humanitarian.atlassian.net/browse/CD-173
+ */
+.cd-header a.cd-site-logo:focus-visible {
+  z-index: var(--cd-z-default);
 }
 
 /* Larger format logo once space permits */

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -116,7 +116,6 @@ ul[data-cd-hidden=true] > ul {
   position: relative;
   display: flex;
   padding: 15px 30px;
-  text-align: left;
   text-decoration: none;
   color: var(--cd-default-text-color);
 }
@@ -125,11 +124,6 @@ ul[data-cd-hidden=true] > ul {
   width: 100%;
   border: 0 none;
   background: transparent;
-}
-
-html[dir="rtl"] .cd-nav a,
-html[dir="rtl"] .cd-nav button {
-  text-align: right;
 }
 
 .cd-nav a:hover,
@@ -239,7 +233,7 @@ html[dir="rtl"] .cd-nav button {
   .cd-nav-level-1__btn::before {
     position: absolute;
     top: 0;
-    left: 15px;
+    margin-inline-start: -15px;
     width: 6px;
     height: 48px;
     content: "";
@@ -260,18 +254,12 @@ html[dir="rtl"] .cd-nav button {
   .cd-nav .menu-item--active-trail button::before {
     position: absolute;
     top: 0;
-    left: 15px;
+    margin-inline-start: -15px;
     width: 6px;
     height: 48px;
     content: "";
     opacity: 0.2;
     background: var(--brand-highlight);
-  }
-
-  [dir="rtl"] .cd-nav .menu-item--active-trail a::before,
-  [dir="rtl"] .cd-nav .menu-item--active-trail button::before {
-    right: 15px;
-    left: auto;
   }
 
   /**
@@ -300,13 +288,7 @@ html[dir="rtl"] .cd-nav button {
   }
 
   .cd-nav > .menu > .menu-item:last-child > ul.menu {
-    right: -1px;
-    left: auto;
-  }
-
-  [dir="rtl"] .cd-nav > .menu > .menu-item:last-child > ul.menu {
-    right: auto;
-    left: -1px;
+    margin-inline-end: -1px;
   }
 
   .cd-nav > .menu > .menu-item.menu-item--active-trail a::before,

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -233,9 +233,9 @@ ul[data-cd-hidden=true] > ul {
   .cd-nav-level-1__btn::before {
     position: absolute;
     top: 0;
-    margin-inline-start: -15px;
     width: 6px;
     height: 48px;
+    margin-inline-start: -15px;
     content: "";
     background: transparent;
   }
@@ -254,9 +254,9 @@ ul[data-cd-hidden=true] > ul {
   .cd-nav .menu-item--active-trail button::before {
     position: absolute;
     top: 0;
-    margin-inline-start: -15px;
     width: 6px;
     height: 48px;
+    margin-inline-start: -15px;
     content: "";
     opacity: 0.2;
     background: var(--brand-highlight);

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -287,8 +287,12 @@ ul[data-cd-hidden=true] > ul {
     flex: 1 0 auto;
   }
 
-  .cd-nav > .menu > .menu-item:last-child > ul.menu {
-    margin-inline-end: -1px;
+  [dir=ltr] .cd-nav > .menu > .menu-item:last-child > ul.menu {
+    right: 0;
+  }
+
+  [dir=rtl] .cd-nav > .menu > .menu-item:last-child > ul.menu {
+    left: 0;
   }
 
   .cd-nav > .menu > .menu-item.menu-item--active-trail a::before,

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -10,11 +10,15 @@
   display: flex;
   align-items: center;
   height: var(--cd-global-header-height);
-  padding: 0;
+  padding: 0 var(--cd-outline-size);
   transition: background 0.3s ease;
   color: var(--cd-white);
   background: transparent;
   font-size: var(--cd-font-size--tiny);
+}
+
+.cd-ocha__btn:focus-visible {
+  outline-offset: calc(0px - var(--cd-outline-size));
 }
 
 .cd-ocha__btn .cd-icon--arrow-down {
@@ -70,16 +74,10 @@
   color: var(--cd-white);
 }
 
-.cd-ocha-dropdown__link a:hover,
-.cd-ocha-dropdown__link a:focus {
-  text-decoration: underline;
-  color: var(--cd-white);
-}
-
-.cd-ocha-dropdown__link a:focus {
-  outline: 3px solid var(--brand-primary--light);
+.cd-ocha-dropdown__link a:focus-visible {
   outline-offset: 8px;
 }
+
 
 /**
  * Selector needs to override CD Button because of source order.

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -134,6 +134,7 @@
 
   .cd-ocha-dropdown__inner {
     flex-flow: row nowrap;
+    align-items: flex-end;
     margin: 0 auto;
     padding: 0 var(--cd-container-padding-tablet);
   }
@@ -143,11 +144,9 @@
     margin-bottom: 0;
   }
 
-  .cd-ocha-dropdown__see-all {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
+  /* it's a cd-button-styled <a> so it has focus styles already */
+  .cd-header a.cd-ocha-dropdown__see-all:focus-visible {
+    outline: none;
   }
 }
 

--- a/components/cd/cd-header/cd-ocha.css
+++ b/components/cd/cd-header/cd-ocha.css
@@ -78,7 +78,6 @@
   outline-offset: 8px;
 }
 
-
 /**
  * Selector needs to override CD Button because of source order.
  */

--- a/components/cd/cd-header/cd-search--inline.css
+++ b/components/cd/cd-header/cd-search--inline.css
@@ -5,6 +5,18 @@
   z-index: var(--cd-z-search);
 }
 
+.cd-search .form-item,
+.cd-search .form-actions,
+.cd-search--inline .form-item,
+.cd-search--inline .form-actions {
+  margin-block: 0;
+}
+
+.cd-search--inline .form-item,
+.cd-search--inline .form-actions {
+  display: flex;
+}
+
 .cd-search--inline__btn {
   display: flex;
   align-items: center;
@@ -53,6 +65,7 @@
   bottom: 0;
   width: 0;
   height: 0;
+  margin-inline-start: -6px;
   content: "";
   border-width: 0 6px 6px;
   border-style: solid;
@@ -61,12 +74,10 @@
 
 [dir=ltr] .cd-search--inline__btn[aria-expanded=true]::before {
   left: 50%;
-  margin-left: -6px;
 }
 
 [dir=rtl] .cd-search--inline__btn[aria-expanded=true]::before {
   right: 50%;
-  margin-right: -6px;
 }
 
 .cd-search--inline__btn[aria-expanded=true] svg {
@@ -109,7 +120,9 @@
   width: 100%;
   max-width: 100%;
   height: calc(var(--cd-site-header-height) - 16px); /* padding */
-  padding: 0 45px 0 25px;
+  padding-block: 0;
+  padding-inline-start: 25px;
+  padding-inline-end: 45px;
   color: var(--cd-default-text-color);
   border: 0;
   border-radius: 0;
@@ -117,11 +130,6 @@
   box-shadow: none;
   font-size: var(--cd-font-size--base);
   -webkit-appearance: none;
-}
-
-[dir=rtl] .cd-search--inline__input[type=search],
-[dir=rtl] .cd-search--inline__input[type=text] {
-  padding: 0 25px 0 45px;
 }
 
 .cd-search--inline__input[type=search]:focus,
@@ -166,8 +174,7 @@
   display: flex;
   align-items: center;
   width: 46px;
-  height: calc(var(--cd-site-header-height) - 16px);
-  /* padding */
+  height: calc(var(--cd-site-header-height) - 16px); /* padding */
   margin: 0;
   padding: 0;
   text-transform: uppercase;
@@ -256,7 +263,9 @@
   .cd-search--inline__input[type=text] {
     box-sizing: content-box;
     height: var(--cd-site-header-height);
-    padding: 0 72px 0 16px;
+    padding-block: 0;
+    padding-inline-start: 16px;
+    padding-inline-end: 72px;
     color: var(--cd-default-text-color);
     border: 0;
     border-radius: 0;
@@ -264,11 +273,6 @@
     box-shadow: none;
     font-size: var(--cd-font-size--small);
     -webkit-appearance: none;
-  }
-
-  [dir=rtl] .cd-search--inline__input[type=search],
-  [dir=rtl] .cd-search--inline__input[type=text] {
-    padding: 0 16px 0 72px;
   }
 
   .cd-search--inline__input[type=search]:focus,
@@ -282,7 +286,14 @@
 @media (min-width: 1024px) {
   .cd-search--inline__input::-webkit-search-cancel-button {
     position: relative;
+  }
+
+  [dir=ltr] .cd-search--inline__input::-webkit-search-cancel-button {
     right: -10px;
+  }
+
+  [dir=rtl] .cd-search--inline__input::-webkit-search-cancel-button {
+    left: -10px;
   }
 }
 
@@ -396,17 +407,4 @@
   .cd-search--inline__submit svg {
     padding: 0;
   }
-}
-
-.cd-search .form-item,
-.cd-search .form-actions,
-.cd-search--inline .form-item,
-.cd-search--inline .form-actions {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.cd-search--inline .form-item,
-.cd-search--inline .form-actions {
-  display: flex;
 }

--- a/components/cd/cd-header/cd-search.css
+++ b/components/cd/cd-header/cd-search.css
@@ -111,6 +111,15 @@
   background: var(--cd-white);
 }
 
+/* If a person uses keyboard nav to re-focus the search button, then we should
+show the outline, overriding the default focus styles for pointer events. */
+.cd-search__btn[aria-expanded=true]:focus-visible {
+  position: relative;
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
+  outline-offset: calc(0px - var(--cd-outline-size));
+  z-index: calc(var(--cd-z-dropdown) + 1);
+}
+
 .cd-search__btn-label {
   text-transform: uppercase;
   font-size: var(--cd-font-size--tiny);

--- a/components/cd/cd-header/cd-search.css
+++ b/components/cd/cd-header/cd-search.css
@@ -115,9 +115,9 @@
 show the outline, overriding the default focus styles for pointer events. */
 .cd-search__btn[aria-expanded=true]:focus-visible {
   position: relative;
+  z-index: calc(var(--cd-z-dropdown) + 1);
   outline: var(--cd-outline-size) solid var(--brand-primary--light);
   outline-offset: calc(0px - var(--cd-outline-size));
-  z-index: calc(var(--cd-z-dropdown) + 1);
 }
 
 .cd-search__btn-label {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -86,8 +86,8 @@
 }
 
 [data-cd-menu-level="1"] {
-  padding-inline: .5rem;
-  padding-block: .5rem;
+  padding-inline: 0.5rem;
+  padding-block: 0.5rem;
 }
 
 .cd-user-menu > .menu-item:last-child > ul.menu {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -61,13 +61,6 @@
   text-decoration: underline;
 }
 
-.cd-user-menu__item:focus,
-.cd-user-menu li a:focus,
-.cd-user-menu li button:focus {
-  outline: 3px solid var(--brand-primary--light);
-  outline-offset: -2px;
-}
-
 .cd-user-menu__item .cd-user-menu__btn-label,
 .cd-user-menu li a .cd-user-menu__btn-label,
 .cd-user-menu li button .cd-user-menu__btn-label {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -82,7 +82,12 @@
 .cd-user-menu__dropdown {
   min-width: 125px;
   margin: 0;
-  padding: 12px 24px;
+  padding: 0;
+}
+
+[data-cd-menu-level="1"] {
+  padding-inline: .5rem;
+  padding-block: .5rem;
 }
 
 .cd-user-menu > .menu-item:last-child > ul.menu {

--- a/css/brand.css
+++ b/css/brand.css
@@ -116,6 +116,11 @@
   --cd-z-skip-link: 1000;
 
   /**
+   * Accessibility-related properties
+   */
+  --cd-outline-size: 3px;
+
+  /**
    * Site-specific brand defaults
    *
    * You can override these defaults in the SUB-THEME. We provide default values

--- a/templates/cd/cd-footer/cd-mandate.html.twig
+++ b/templates/cd/cd-footer/cd-mandate.html.twig
@@ -3,6 +3,7 @@
     <span class="cd-mandate__heading">{{ 'Service provided by'|t }}</span>
     <span class="cd-mandate__logo">
       <span class="visually-hidden">{{ 'United Nations Office for the Coordination of Humanitarian Affairs'|t }}</span>
+      {{ source('@common_design/img/logos/ocha-lockup.svg') }}
     </span>
     <span class="cd-mandate__text">
       {{ 'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.'|t }}

--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -40,7 +40,7 @@
 
     {% set parent_id = attributes.id ?? ('cd-user-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes) }}>
+    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
 
     {% for item in items %}
       {%

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -40,7 +40,7 @@
 
     {% set parent_id = attributes.id ?? ('cd-help-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes) }}>
+    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
 
     {% for item in items %}
       {%


### PR DESCRIPTION
## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Continuing to remove directional properties in favor of logical properties. This PR is limited to CD Header/Footer; the components can be cleaned up on an individual basis.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Expected behavior
<!--- Describe what should happen. -->

## Actual behavior
<!--- Describe what actually happens. -->

## Steps to reproduce the problem or Steps to test

  1. View an LTR page and an RTL page. Compare to them to each other, and web.brand.
  1. Pretty much any change in appearance is a regression (exceptions following)

### Exceptions

- **Footer mandate logo** has been intentionally adjusted. The logo had a vertical alignment applied which was LTR specific, based on the top edge of the letters in the logo. For RTL, this created a strange effect. The adjustment has simply been removed, meaning the logo is a few pixels lower than it used to be. It's border is now full-height against however many lines of mandate text exist (3-LTR and 2-RTL in my testing)
- **Footer copyright text** has a greater max-width, so that it collapses to 2 lines of text in the larger mobile layouts.
- **Footer copyright logo** was nudged a few pixels so that it precisely lines up in the center of the copyright text.
  
## Impact
IE 11 and older will no longer render things 100% correctly.

Purely as a coding-style, Any un-scoped LTR-only styles were refactored to live inside `[dir=ltr]` so that grepping the codebase for `dir=` should return any and all directional styles. Additionally, it means we can do informal testing by removing the `<html dir>` attribute and see what changes.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
