### PR TITLE
fix: adjust appearance of active trail on mobile/desktop

### DIFF
--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -250,8 +250,8 @@ ul[data-cd-hidden=true] > ul {
     background: var(--brand-highlight);
   }
 
-  .cd-nav .menu-item--active-trail a::before,
-  .cd-nav .menu-item--active-trail button::before {
+  .cd-nav .menu-item--active-trail > a::before,
+  .cd-nav .menu-item--active-trail > button::before {
     position: absolute;
     top: 0;
     width: 6px;
@@ -293,6 +293,7 @@ ul[data-cd-hidden=true] > ul {
 
   .cd-nav > .menu > .menu-item.menu-item--active-trail a::before,
   .cd-nav > .menu > .menu-item.menu-item--active-trail button::before {
+    opacity: 0.2;
     background: var(--brand-highlight);
   }
 


### PR DESCRIPTION
# CD-461

Adjusting active-trail for consistency and a11y.

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
I adjusted the active trail so that mobile/desktop use the same convention, and so that keyboard nav is slightly improved since active trail on Desktop is no longer the same as the active/focused link.

## Motivation and Context
Stumbled upon as part of CD-453 as we improved RTL of base-theme CSS.

## Steps to reproduce the problem or Steps to test

  1. Click a second-level nav item and load the page
  1. Compare mobile/desktop active trails, and compare to web.brand as a control.

Screenshots in ticket CD-461.  
  
## Impact
No steps to upgrade, no impact unless CD Nav styles have been intentionally customized.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
