### PR TITLE
[CD-469] fix overflow on search dropdown for viewports 320 > 420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [8.0.2](https://github.com/UN-OCHA/common_design/compare/v8.0.1...v8.0.2) (2023-04-12)
-
+## [8.0.2](https://github.com/UN-OCHA/common_design/compare/v8.0.1...v8.0.2) (2023-04-12)
 
 ### Bug Fixes
 
@@ -23,6 +22,7 @@ All notable changes to this project will be documented in this file. See [standa
 * use logical properties for CD Nav ([3e67b9e](https://github.com/UN-OCHA/common_design/commit/3e67b9ebf575ad92e79995c5aca73805ca265dc2))
 * use the intended color for focus styles in base-theme ([728fbe2](https://github.com/UN-OCHA/common_design/commit/728fbe2c8f2ea33e20050ab7bb64adb9ea0559ae))
 * z-index issue with Site Logo and OCHA Services dropdown ([0c26b0e](https://github.com/UN-OCHA/common_design/commit/0c26b0e4d2ea377800955ee300e8ad8490430245))
+
 
 ## [8.0.1](https://github.com/UN-OCHA/common_design/compare/v8.0.0...v8.0.1) (2023-03-22)
 

--- a/components/cd/cd-header/cd-search.css
+++ b/components/cd/cd-header/cd-search.css
@@ -19,7 +19,7 @@
 }
 
 .cd-search__form .form-type-textfield {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 .cd-search__form .form-actions {


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
I noticed this while doing some WP upgrades. Screenshot in CD-469.

## Steps to reproduce the problem or Steps to test

  1. Use a smartphone with viewport in between 320px and 420px wide to toggle Search
  1. Before PR, it will cause viewport overflow
  1. After PR, no overflow
  
## Impact
No impact.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
