### PR TITLE
Use drupal_static() instead of PHPs static keyword

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -715,7 +715,7 @@ function common_design_load_theme_blocks(array $ids) {
  *   before to avoid displaying the block several times.
  */
 function common_design_get_block_render_array($id) {
-  static $rendered = [];
+  $rendered = &drupal_static(__FUNCTION__, []);
 
   if (!isset($rendered[$id])) {
     // Prevent rendering the block several times.


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
I suggest using the `drupal_static()` pattern instead of directly using PHPs built-in `static` keyword for keeping track of rendered page title blocks. This is inline with Drupals suggested use-case as described in https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/drupal_static/10.0.x and it also makes it possible to clear the static cache if needed.

## Motivation and Context
Using the diff module to compare revisions, changes in the page title are not correctly detected, because the 2 revisions that are compared are rendered as part of the same request. It would be possible to work around that if resetting the static variable cache would be possible. After this change request it would be trivial to call `drupal_static_reset('common_design_get_block_render_array');` between the rendering.
  
## Impact
No changes needed. The current functionality is 100% preserved.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
