### PR TITLE
[CD-475] Simplify how you override mobile logo

### DIFF
--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -24,8 +24,20 @@ Refer to [Drupal 9+ Theming documentation][theming-docs] for more information.
 
 ### Customise the logo
 
-- Set the logo `logo: 'img/logos/your-logo.svg'` in the `common_design_subtheme.info.yml` file.
-- Adjust `--brand-logo-width` inside `css/brand.css`
+The theme uses two logos: by default the UN emblem, and on wider screens the OCHA lockup (emblem plus "OCHA"). To configure both follow these steps:
+
+1. **Desktop:** Add your file to `img/logos` and set the **desktop logo** in the `common_design_subtheme.info.yml` file
+
+```
+logo: 'img/logos/your-desktop-logo.svg'
+```
+
+Adjust `--brand-logo-desktop-width` to match your logo's dimensions
+
+2. **Mobile:** Check your mobile logo into version control and adjust the following variables inside `css/brand.css` to match the file's location and dimensions:
+
+  - `--brand-logo-mobile-url`
+  - `--brand-logo-mobile-width`
 
 
 ### Customise the favicon and homescreen icons

--- a/common_design_subtheme/common_design_subtheme.info.yml.example
+++ b/common_design_subtheme/common_design_subtheme.info.yml.example
@@ -37,9 +37,9 @@ libraries:
 #
 # @see common_design_subtheme.libraries.yml
 #
-# libraries-extend:
-#   common_design/cd-teaser:
-#     - common_design_subtheme/custom-teaser
+libraries-extend:
+  common_design/cd-header:
+    - common_design_subtheme/cd-header
 
 ###
 # Override libraries to replace specific base-theme components. Now, when the

--- a/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -11,7 +11,7 @@ global-styling:
     base:
       css/brand.css: {}
       css/styles.css: {}
-#    theme:
+#     theme:
 #   dependencies:
 #     - common_design_subtheme/custom-teaser
 
@@ -27,6 +27,11 @@ global-styling:
 #   css:
 #     theme:
 #       components/custom-teaser/custom-teaser.css: {}
+
+cd-header:
+  css:
+    theme:
+      components/cd/cd-header/cd-logo.css
 
 ###
 # Define Drupal libraries for additional webfonts.

--- a/common_design_subtheme/components/cd/cd-header/cd-logo.css
+++ b/common_design_subtheme/components/cd/cd-header/cd-logo.css
@@ -1,0 +1,12 @@
+/**
+ * Common Design: Logo
+ *
+ * Overrides the image path. All other rules are defined in CD Header itself.
+ * This rule exists so that the values in brand.css resolve relative to this
+ * sub-theme instead of the base-theme.
+ */
+.cd-site-logo {
+  background:
+    linear-gradient(transparent, transparent),
+    var(--brand-logo-mobile-url) center no-repeat;
+}

--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -9,6 +9,13 @@
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);
+
+  /**
+   * Site logos
+   *
+   * Specify the logo paths/dimentions here. The URL is relative to
+   * common_design_subtheme/components/cd/cd-header/cd-logo.css
+   */
   --brand-logo-mobile-url: url("../../../img/logos/ocha-logo-blue.svg");
   --brand-logo-mobile-width: 52px;
   --brand-logo-desktop-width: 186px;

--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -5,7 +5,7 @@
    * Set these variables and the CD Header/Footer will re-color to your brand.
    */
   --brand-primary: var(--cd-ocha-blue);
-  --brand-primary--light: var(--cd-blue--brighter);
+  --brand-primary--light: var(--cd-blue--bright);
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);

--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -9,5 +9,10 @@
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);
-  --brand-logo-width: 186px;
+  --brand-logo-mobile-url: url("../../../img/logos/ocha-logo-blue.svg");
+  --brand-logo-mobile-width: 52px;
+  --brand-logo-desktop-width: 186px;
+
+  /* DEPRECATED: this variable will be removed in the future */
+  --brand-logo-width: var(--brand-logo-desktop-width);
 }

--- a/components/cd/cd-header/cd-logo.css
+++ b/components/cd/cd-header/cd-logo.css
@@ -4,7 +4,7 @@
  * Replace images with your site logo.
  */
 
-/* Wrap the logo in h1 if it's the main heading for the page (e.g. on homepage). */
+/* Logo is wrapped in H1 since it serves as top-level of outline. */
 .cd-site-header h1 {
   margin: 0;
 }

--- a/components/cd/cd-header/cd-logo.css
+++ b/components/cd/cd-header/cd-logo.css
@@ -12,10 +12,16 @@
 .cd-site-logo {
   display: block;
   float: left;
-  width: 52px;
+  width: var(--brand-logo-mobile-width, 52px);
   height: var(--cd-site-header-height);
-  background: url("../../../img/logos/ocha-logo-blue@53x37.png") center no-repeat;
-  background: linear-gradient(transparent, transparent), url("../../../img/logos/ocha-logo-blue.svg") center no-repeat;
+  background:
+    linear-gradient(transparent, transparent),
+    var(--brand-logo-mobile-url) center no-repeat;
+}
+
+/* Hides logo set in info.yml on mobile, in favour of background image. */
+.cd-site-logo img {
+  display: none;
 }
 
 /**
@@ -28,26 +34,23 @@
   z-index: var(--cd-z-default);
 }
 
-/* Larger format logo once space permits */
+/**
+ * Desktop logo
+ *
+ * Larger format logo once space permits
+ */
 @media (min-width: 768px) {
   .cd-site-logo {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     justify-content: center;
-    width: var(--brand-logo-width); /* adjust within sub-theme's brand.css */
+    width: var(--brand-logo-desktop-width); /* adjust within sub-theme's brand.css */
     padding-top: 0;
     background: none;
   }
-}
 
-/* Hides logo set in info.yml on mobile, in favour of background image. */
-.cd-site-logo img {
-  display: none;
-}
-
-/* Displays logo set in info.yml on larger viewports. */
-@media (min-width: 768px) {
+  /* Displays logo set in info.yml on larger viewports. */
   .cd-site-logo img {
     display: block;
     width: 100%;

--- a/components/cd/cd-header/cd-site-header.css
+++ b/components/cd/cd-header/cd-site-header.css
@@ -24,12 +24,12 @@ now that we layout with flex. */
 }
 
 .cd-site-header__inner .region-header-logo {
-  flex: 0 0 52px;
+  flex: 0 0 var(--brand-logo-mobile-width);
 }
 
 @media (min-width: 768px) {
   .cd-site-header__inner .region-header-logo {
-    flex: 0 0 var(--brand-logo-width);
+    flex: 0 0 var(--brand-logo-desktop-width);
   }
 }
 

--- a/components/cd/cd-header/cd-site-header.css
+++ b/components/cd/cd-header/cd-site-header.css
@@ -67,9 +67,9 @@ now that we layout with flex. */
 }
 
 /**
- * No-JS styles
+ * JS-disabled styles
  *
- * In the even JS doesn't execute at all, these styles will apply. In cases
+ * In the event JS doesn't execute at all, these styles will apply. In cases
  * JS fails to load, or times out, these styles will NOT apply, because our
  * inline script will have taken this classname off the <html> element.
  */

--- a/css/brand.css
+++ b/css/brand.css
@@ -134,5 +134,10 @@
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);
-  --brand-logo-width: 186px;
+  --brand-logo-mobile-url: url("../../../img/logos/ocha-logo-blue.svg");
+  --brand-logo-mobile-width: 52px;
+  --brand-logo-desktop-width: 186px;
+
+  /* DEPRECATED: this variable will be removed in the future */
+  --brand-logo-width: var(--brand-logo-desktop-width);
 }

--- a/css/brand.css
+++ b/css/brand.css
@@ -134,6 +134,13 @@
   --brand-primary--dark: var(--cd-blue--dark);
   --brand-highlight: var(--cd-highlight-red);
   --brand-grey: var(--cd-blue-grey);
+
+  /**
+   * Site logos
+   *
+   * Specify the logo paths/dimentions here. The URL is relative to
+   * common_design/components/cd/cd-header/cd-logo.css
+   */
   --brand-logo-mobile-url: url("../../../img/logos/ocha-logo-blue.svg");
   --brand-logo-mobile-width: 52px;
   --brand-logo-desktop-width: 186px;


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- :heavy_check_mark: New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
One of the most common tasks is to override the site logo. While doing some upgrades recently I botched it up, and decided that the `brand.css` really should be a home for the mobile logo as well. The PR makes it possible to override the mobile logo by specifying an image in the filesystem. The sub-theme has an override for CD Header enabled by default so that the variable in `brand.css` will be relative to the subtheme's copy of the `cd-logo.css` file.

For now it has to be relative to the same place as the base-theme, `components/cd/cd-header/cd-logo.css` — I thought about getting really whacky and placing the file in the theme root to get vars with URLs like below, but decided the once-per-project DX improvement wasn't worth the complexity of maintaining the file so far away from all the others.

```css
:root {
  --brand-logo-mobile-url: url("./img/logos/my-logo.svg");
}
```

## Steps to reproduce the problem or Steps to test

  1. Install a fresh sub-theme and configure `brand.css`
  1. Make sure the logo(s) you specify exists in the filesystem
  1. Rebuild cache
  
  
## Impact
If a sub-theme already overrode their mobile logo by another means, then this will not affect the website. It's for new sub-themes.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have made changes to the sub-theme to reflect those in the base-theme
