### PR TITLE
[CD-476] Improve screen reading

### DIFF
--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -10,6 +10,7 @@
   margin: 0;
   padding-inline-start: 0;
   list-style: none;
+  position: relative;
 }
 
 .cd-user-menu ul {

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -1,5 +1,9 @@
 /**
- * Common Design: User Menu
+ * Common Design: User Menus
+ *
+ * User menus are the dropdowns in the Global Header, such as Help or Account.
+ * Site configuration can affect how many of them are displayed, but they all
+ * get styled in a similar fashion.
  */
 
 .cd-user-menu {
@@ -21,11 +25,12 @@
  *
  * @TODO: add proper classes to make it more robust.
  */
+.cd-global-header__user-menu svg + span,
 .cd-user-menu svg + span {
   margin-inline-start: 10px;
 }
 
-/* Other icons, for example user or help icon. */
+/* Other icons, for example Help/Account icons. */
 .cd-user-menu .cd-icon:not(.cd-icon--arrow-down) {
   width: 14px;
   height: 14px;
@@ -33,12 +38,11 @@
 
 .cd-user-menu li {
   position: relative;
-  float: left;
 }
 
 .cd-user-menu__item,
-.cd-user-menu li a,
-.cd-user-menu li button {
+.cd-user-menu a,
+.cd-user-menu button {
   position: relative;
   display: flex;
   align-items: center;
@@ -53,17 +57,17 @@
 }
 
 .cd-user-menu__item:hover,
-.cd-user-menu li a:hover,
-.cd-user-menu li button:hover,
+.cd-user-menu a:hover,
+.cd-user-menu button:hover,
 .cd-user-menu__item:focus,
-.cd-user-menu li a:focus,
-.cd-user-menu li button:focus {
+.cd-user-menu a:focus,
+.cd-user-menu button:focus {
   text-decoration: underline;
 }
 
 .cd-user-menu__item .cd-user-menu__btn-label,
-.cd-user-menu li a .cd-user-menu__btn-label,
-.cd-user-menu li button .cd-user-menu__btn-label {
+.cd-user-menu a .cd-user-menu__btn-label,
+.cd-user-menu button .cd-user-menu__btn-label {
   position: relative;
   display: block;
   overflow: hidden;
@@ -73,8 +77,8 @@
 
 @media (min-width: 768px) {
   .cd-user-menu__item .cd-user-menu__btn-label,
-  .cd-user-menu li a .cd-user-menu__btn-label,
-  .cd-user-menu li button .cd-user-menu__btn-label {
+  .cd-user-menu a .cd-user-menu__btn-label,
+  .cd-user-menu button .cd-user-menu__btn-label {
     max-width: unset;
   }
 }

--- a/components/cd/cd-header/cd-user-menu.css
+++ b/components/cd/cd-header/cd-user-menu.css
@@ -7,10 +7,10 @@
  */
 
 .cd-user-menu {
+  position: relative;
   margin: 0;
   padding-inline-start: 0;
   list-style: none;
-  position: relative;
 }
 
 .cd-user-menu ul {

--- a/img/logos/ocha-lockup.svg
+++ b/img/logos/ocha-lockup.svg
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="149px" height="37px" viewBox="0 0 149 37" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
-    <title>Artboard</title>
-    <desc>Created with Sketch.</desc>
+    <title>UN OCHA</title>
+    <desc>United Nations Office for the Coordination of Humanitarian Affairs</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Artboard" fill-rule="nonzero" fill="#FFFFFF">

--- a/templates/block/block--language-block.html.twig
+++ b/templates/block/block--language-block.html.twig
@@ -36,23 +36,17 @@
   'cd-global-header__language-switcher'
 ]
 %}
-
-<div{{ attributes.addClass(classes) }}>
+{% set aria_label = 'Language'|t %}
+<div{{ attributes.addClass(classes)|without('role') }}>
   <div{{ create_attribute({
     'class': ['cd-language-switcher', 'cd-dropdown'],
     'id': 'cd-language',
-    'aria-labelledby': 'cd-language-switcher',
     'data-cd-toggable': "#{language_name}",
     'data-cd-icon': 'arrow-down',
     'data-cd-component': 'cd-language-switcher',
+    'role': 'navigation',
+    'aria-label': aria_label,
   }) }}>
-    {# Label. If not displayed, we still provide it for screen readers. #}
-    {% if not configuration.label_display %}
-      {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-    {% endif %}
-    {{ title_prefix }}
-    <h2{{ title_attributes.setAttribute('id', 'cd-language-switcher').addClass('visually-hidden') }}>{{ configuration.label }}</h2>
-    {{ title_suffix }}
 
     {% block content %}
       {{ content }}

--- a/templates/block/block--language-block.html.twig
+++ b/templates/block/block--language-block.html.twig
@@ -38,19 +38,16 @@
 %}
 {% set aria_label = 'Language'|t %}
 <div{{ attributes.addClass(classes)|without('role') }}>
-  <div{{ create_attribute({
+  <nav{{ create_attribute({
     'class': ['cd-language-switcher', 'cd-dropdown'],
     'id': 'cd-language',
     'data-cd-toggable': "#{language_name}",
     'data-cd-icon': 'arrow-down',
     'data-cd-component': 'cd-language-switcher',
-    'role': 'navigation',
     'aria-label': aria_label,
   }) }}>
-
     {% block content %}
       {{ content }}
     {% endblock %}
-
-  </div>
+  </nav>
 </div>

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -1,3 +1,10 @@
-<a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="cd-site-logo">
-  <img src="{{ site_logo }}" alt="{{ site_name }}" aria-label="{{ 'Home'|t }}" width="100%" height="60px" />
+{#
+/**
+ * @file
+ * Theme override for system branding block (site logo).
+ */
+#}
+<a href="{{ path('<front>') }}" title="{{ 'Front page'|t }}" rel="home" class="cd-site-logo">
+  <img src="{{ site_logo }}" alt="{{ site_name }}" aria-hidden="true" width="100%" height="60px" />
+  <span class="visually-hidden">{{ site_name }}</span>
 </a>

--- a/templates/block/block--system-menu-block--account.html.twig
+++ b/templates/block/block--system-menu-block--account.html.twig
@@ -31,6 +31,7 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
+{{ attach_library('common_design/cd-user-menu') }}
 {%
   set classes = [
     'block',
@@ -40,19 +41,8 @@
     'cd-global-header__user-menu'
   ]
 %}
-
-{{ attach_library('common_design/cd-user-menu') }}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" {{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id).addClass('visually-hidden') }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
-  {# Menu. #}
+{% set aria_label = 'Account'|t %}
+<nav{{ attributes.addClass(classes).setAttribute('aria-label', aria_label) }}>
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--system-menu-block--account.html.twig
+++ b/templates/block/block--system-menu-block--account.html.twig
@@ -38,11 +38,11 @@
     'block-menu',
     'navigation',
     'menu--' ~ derivative_plugin_id|clean_class,
-    'cd-global-header__user-menu'
+    'cd-global-header__user-menu',
+    'cd-user-menu',
   ]
 %}
-{% set aria_label = 'Account'|t %}
-<nav{{ attributes.addClass(classes).setAttribute('aria-label', aria_label) }}>
+<nav{{ attributes.addClass(classes).setAttribute('aria-label', 'Account'|t) }}>
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--system-menu-block--footer.html.twig
+++ b/templates/block/block--system-menu-block--footer.html.twig
@@ -34,17 +34,7 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id).addClass('visually-hidden') }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
-  {# Menu. #}
+<nav aria-label="{{ 'Footer'|t }}"{{ attributes|without('role', 'aria-label', 'aria-labelledby') }}>
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--system-menu-block--help.html.twig
+++ b/templates/block/block--system-menu-block--help.html.twig
@@ -31,6 +31,7 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
+{{ attach_library('common_design/cd-user-menu') }}
 {%
   set classes = [
     'block',
@@ -40,19 +41,8 @@
     'cd-global-header__user-menu'
   ]
 %}
-
-{{ attach_library('common_design/cd-user-menu') }}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" {{ attributes.setAttribute('aria-labelledby', heading_id).addClass(classes)|without('role') }}>
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id).addClass('visually-hidden') }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
-  {# Menu. #}
+{% set aria_label = 'Help'|t %}
+<nav{{ attributes.addClass(classes).setAttribute('aria-label', aria_label) }}>
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--system-menu-block--help.html.twig
+++ b/templates/block/block--system-menu-block--help.html.twig
@@ -38,11 +38,11 @@
     'block-menu',
     'navigation',
     'menu--' ~ derivative_plugin_id|clean_class,
-    'cd-global-header__user-menu'
+    'cd-global-header__user-menu',
+    'cd-user-menu',
   ]
 %}
-{% set aria_label = 'Help'|t %}
-<nav{{ attributes.addClass(classes).setAttribute('aria-label', aria_label) }}>
+<nav{{ attributes.addClass(classes).setAttribute('aria-label', 'Help'|t) }}>
   {% block content %}
     {{ content }}
   {% endblock %}

--- a/templates/block/block--system-menu-block--main.html.twig
+++ b/templates/block/block--system-menu-block--main.html.twig
@@ -42,24 +42,13 @@
   ]
 %}
 
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" {{ attributes
-  .setAttribute('aria-labelledby', heading_id)
+{% set aria_label = 'Main'|t %}
+<nav{{ attributes
+  .setAttribute('aria-label', aria_label)
   .setAttribute('data-cd-toggable', 'Menu'|t)
   .setAttribute('data-cd-component', 'cd-nav-level-0')
   .setAttribute('data-cd-icon', 'arrow-down')
-  .addClass(classes)|without('role') }}>
-
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes
-    .setAttribute('id', heading_id)
-    .addClass('visually-hidden') }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
+  .addClass(classes)|without('role', 'aria-labelledby') }}>
   {# Menu. #}
   {% block content %}
     {{ content }}

--- a/templates/cd/cd-footer/cd-copyright.html.twig
+++ b/templates/cd/cd-footer/cd-copyright.html.twig
@@ -1,6 +1,7 @@
 {% set cc = link('Creative Commons BY 4.0'|t, 'https://creativecommons.org/licenses/by/4.0')|render %}
 <div class="cd-footer__section cd-footer__section--copyright">
   <div class="cd-footer-copyright">
+    <h3 class="visually-hidden">{{ 'Copyright notice'|t }}</h3>
     <span class="cd-footer-copyright__text">{% trans %}Except where otherwise noted, content on this site is licensed under a {{ cc }} International license.{% endtrans %}</span>
     <a class="cd-footer-copyright__link" href="https://creativecommons.org/licenses/by/4.0/">
       <span class="visually-hidden">{{ 'Creative Commons BY 4.0'|t }}</span>

--- a/templates/cd/cd-footer/cd-footer-menu.html.twig
+++ b/templates/cd/cd-footer/cd-footer-menu.html.twig
@@ -1,7 +1,9 @@
-{# Displays footer navigation #}
-
+{#
+/**
+ * @file
+ * CD Footer - Footer navigation
+ */
+#}
 <div class="cd-footer__section cd-footer__section--menu">
-
   {{ page.footer_navigation }}
-
 </div>

--- a/templates/cd/cd-footer/cd-footer.html.twig
+++ b/templates/cd/cd-footer/cd-footer.html.twig
@@ -1,8 +1,12 @@
-{# Displays the site footer #}
-
+{#
+/**
+ * @file
+ * Top-level template for CD Footer.
+ */
+#}
 {{ attach_library('common_design/cd-ocha-services') }}
 
-<footer class="cd-footer" role="contentinfo">
+<footer class="cd-footer" role="contentinfo" aria-label="{{ 'Site footer'|t }}">
   <div class="cd-container cd-footer__inner">
 
     {% block footer_menu %}
@@ -18,11 +22,10 @@
       {% include '@common_design/cd/cd-footer/cd-copyright.html.twig' %}
     {% endblock %}
 
-
+    {# JS will move this into the Global Header #}
     {% block ocha %}
       {% include '@common_design/cd/cd-header/cd-ocha.html.twig' %}
     {% endblock %}
 
   </div>
 </footer>
-

--- a/templates/cd/cd-footer/cd-mandate.html.twig
+++ b/templates/cd/cd-footer/cd-mandate.html.twig
@@ -3,7 +3,7 @@
     <span class="cd-mandate__heading">{{ 'Service provided by'|t }}</span>
     <span class="cd-mandate__logo">
       <span class="visually-hidden">{{ 'United Nations Office for the Coordination of Humanitarian Affairs'|t }}</span>
-      {{ source('@common_design/img/logos/ocha-lockup.svg') }}
+      <span aria-hidden="true">{{ source('@common_design/img/logos/ocha-lockup.svg') }}</span>
     </span>
     <span class="cd-mandate__text">
       {{ 'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.'|t }}

--- a/templates/cd/cd-footer/cd-social-menu.html.twig
+++ b/templates/cd/cd-footer/cd-social-menu.html.twig
@@ -1,4 +1,10 @@
-<div class="cd-footer__section cd-footer__section--social cd-footer-social">
+{#
+/**
+ * @file
+ * CD Footer - Social navigation
+ */
+#}
+<nav aria-label="{{ 'Social'|t }}" class="cd-footer__section cd-footer__section--social cd-footer-social">
   {% block social_media %}
 
     <ul class="cd-footer-social__list">
@@ -77,4 +83,4 @@
     </ul>
 
   {% endblock %}
-</div>
+</nav>

--- a/templates/cd/cd-header/cd-header.html.twig
+++ b/templates/cd/cd-header/cd-header.html.twig
@@ -1,6 +1,10 @@
-{# Displays the site header #}
-
-<header role="banner" class="cd-header" aria-label="{{ 'Website header'|t }}">
+{#
+/**
+ * @file
+ * Top-level template for CD Header.
+ */
+#}
+<header role="banner" class="cd-header" aria-label="{{ 'Site header'|t }}">
 
   {% block header_content %}
     {% include '@common_design/cd/cd-header/cd-global-header.html.twig' %}

--- a/templates/cd/cd-header/cd-header.html.twig
+++ b/templates/cd/cd-header/cd-header.html.twig
@@ -1,6 +1,6 @@
 {# Displays the site header #}
 
-<header class="cd-header">
+<header role="banner" class="cd-header" aria-label="{{ 'Website header'|t }}">
 
   {% block header_content %}
     {% include '@common_design/cd/cd-header/cd-global-header.html.twig' %}

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -44,9 +44,7 @@
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.
     #}
-    <a href="#main-content" class="visually-hidden focusable skip-link">
-      {{ 'Skip to main content'|t }}
-    </a>
+    <a href="#main-content" class="visually-hidden focusable skip-link">{{ 'Skip to main content'|t }}</a>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -41,16 +41,13 @@
   </header>
 
   {# Link to skip to the main content is in html.html.twig #}
-  <main role="main" id="main-content" class="cd-container">
+  <main role="main" aria-label="{{ 'Page content'|t }}" id="main-content" class="cd-container">
 
     <h1 class="cd-page-title">{{ title }}</h1>
 
     <div class="cd-layout">
-
       <div class="cd-layout__content">
-
-      {{ page.content }}
-
+        {{ page.content }}
       </div>{# /.layout-content #}
     </div>
   </main>

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -24,9 +24,9 @@
 
         <div class="region region-header-logo">
           <h1>
-            <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="cd-site-logo">
+            <a href="{{ path('<front>') }}" title="{{ 'Front page'|t }}" rel="home" class="cd-site-logo">
+              <img src="{{ logo }}" alt="{{ site_name }}" aria-hidden="true" width="100%" height="60px" />
               <span class="visually-hidden">{{ site_name }}</span>
-              <img src="{{ logo }}" alt="{{ 'Home'|t }}" />
             </a>
           </h1>
         </div>

--- a/templates/layout/maintenance-page.html.twig
+++ b/templates/layout/maintenance-page.html.twig
@@ -11,7 +11,7 @@
 #}
 <div class="cd-page-layout-container">
 
-  <header class="cd-header">
+  <header role="banner" class="cd-header" aria-label="{{ 'Site header'|t }}">
 
     <div class="cd-global-header">
       <div class="cd-container cd-global-header__inner">
@@ -55,7 +55,7 @@
     </div>
   </main>
 
-  <footer class="cd-footer" role="contentinfo">
+  <footer class="cd-footer" role="contentinfo" aria-label="{{ 'Site footer'|t }}">
     <div class="cd-container cd-footer__inner">
 
       {% block mandate %}

--- a/templates/layout/page--404.html.twig
+++ b/templates/layout/page--404.html.twig
@@ -2,16 +2,14 @@
 
   {% block main %}
     {# Link to skip to the main content is in html.html.twig #}
-    <main role="main" id="main-content" class="cd-container">
+    <main role="main" aria-label="{{ 'Page content'|t }}" id="main-content" class="cd-container">
 
       {{ page.page_title }}
 
       <div class="cd-layout">
-
         <div class="cd-layout__content">
           {{ page.content }}
         </div>{# /.cd-layout__content #}
-
       </div>
 
     </main>

--- a/templates/layout/page--demo.html.twig
+++ b/templates/layout/page--demo.html.twig
@@ -108,7 +108,7 @@
   </div>
 
   {# Link to skip to the main content is in html.html.twig #}
-  <main role="main" id="main-content" class="cd-container">
+  <main role="main" aria-label="{{ 'Page content'|t }}" id="main-content" class="cd-container">
 
     <div class="cd-demo-content">
 

--- a/templates/layout/page--facets.html.twig
+++ b/templates/layout/page--facets.html.twig
@@ -8,7 +8,7 @@
 
   {% block main %}
     {# Link to skip to the main content is in html.html.twig #}
-    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(facets_layout_classes) }}>
+    <main role="main" aria-label="{{ 'Page content'|t }}" id="main-content" {{ attributes.addClass(facets_layout_classes) }}>
 
       {{ page.page_title }}
 

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -75,7 +75,7 @@
 
   {% block main %}
     {# Link to skip to the main content is in html.html.twig #}
-    <main role="main" {{ attributes.setAttribute('id', 'main-content').addClass(layout_classes) }}>
+    <main role="main" aria-label="{{ 'Page content'|t }}" id="main-content" {{ attributes.addClass(layout_classes) }}>
 
       {{ page.page_title }}
 

--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -16,6 +16,20 @@
  *   - is_collapsed: TRUE if the link has children within the current menu tree
  *     that are not currently visible.
  *   - in_active_trail: TRUE if the link is in the active trail.
+ *
+ * This template assumes that your Account nav uses one active top-level menu
+ * item with all other menu items nested flatly underneath. In practice, we use
+ * two mutually-exclusive top-level menu items based on whether the person is
+ * logged in out out. Your nav MUST look like this for the template to function:
+ *
+ * My Account (logged-in)
+ *  ↳ Optional: site-specific user action(s)
+ *  ↳ Log out
+ * Log in (logged-out)
+ *
+ * <ul>/<li> tags are commented out for menu_level 0. Omitting these tags is for
+ * the benefit of screen readers, who announce fewer items before landing on the
+ * toggle button.
  */
 #}
 {% import _self as menus %}

--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -40,10 +40,12 @@
 
     {% set parent_id = attributes.id ?? ('cd-user-menu-' ~ menu_level) %}
 
-    <ul{{ attributes
-      .addClass(menu_classes)
-      .setAttribute('data-cd-menu-level', menu_level)
-    }}>
+    {% if menu_level != 0 %}
+      <ul{{ attributes
+        .addClass(menu_classes)
+        .setAttribute('data-cd-menu-level', menu_level)
+      }}>
+    {% endif %}
 
     {% for item in items %}
       {%
@@ -57,7 +59,7 @@
 
       {% set id = (parent_id ~ '-item-' ~ loop.index)|clean_id %}
 
-      <li{{ item.attributes.addClass(classes) }}>
+      {% if menu_level != 0 %}<li{{ item.attributes.addClass(classes) }}>{% endif %}
 
         {#
           Progressive enhancement: make sure there is always a menu entry.
@@ -100,11 +102,9 @@
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
 
         {% endif %}
-
-      </li>
-
-    {% endfor %}
-    </ul>
+        {% if menu_level != 0 %}</li>{% endif %}
+      {% endfor %}
+    {% if menu_level != 0 %}</ul>{% endif %}
   {% endif %}
 {% endmacro %}
 

--- a/templates/navigation/menu--account.html.twig
+++ b/templates/navigation/menu--account.html.twig
@@ -40,7 +40,10 @@
 
     {% set parent_id = attributes.id ?? ('cd-user-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
+    <ul{{ attributes
+      .addClass(menu_classes)
+      .setAttribute('data-cd-menu-level', menu_level)
+    }}>
 
     {% for item in items %}
       {%

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -16,6 +16,17 @@
  *   - is_collapsed: TRUE if the link has children within the current menu tree
  *     that are not currently visible.
  *   - in_active_trail: TRUE if the link is in the active trail.
+ *
+ * This template assumes that your Help nav uses one active top-level menu
+ * item with all other menu items nested flatly underneath. Your nav MUST look
+ * like this for the template to function:
+ *
+ * Help
+ *  ↳ Optional: site-specific user action(s)
+ *
+ * <ul>/<li> tags are commented out for menu_level 0. Omitting these tags is for
+ * the benefit of screen readers, who announce fewer items before landing on the
+ * toggle button.
  */
 #}
 {% import _self as menus %}

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -40,7 +40,10 @@
 
     {% set parent_id = attributes.id ?? ('cd-help-menu-' ~ menu_level) %}
 
-    <ul{{ attributes.addClass(menu_classes).setAttribute('data-cd-menu-level', menu_level) }}>
+    <ul{{ attributes
+      .addClass(menu_classes)
+      .setAttribute('data-cd-menu-level', menu_level)
+    }}>
 
     {% for item in items %}
       {%

--- a/templates/navigation/menu--help.html.twig
+++ b/templates/navigation/menu--help.html.twig
@@ -40,10 +40,12 @@
 
     {% set parent_id = attributes.id ?? ('cd-help-menu-' ~ menu_level) %}
 
-    <ul{{ attributes
-      .addClass(menu_classes)
-      .setAttribute('data-cd-menu-level', menu_level)
-    }}>
+    {% if menu_level != 0 %}
+      <ul{{ attributes
+        .addClass(menu_classes)
+        .setAttribute('data-cd-menu-level', menu_level)
+      }}>
+    {% endif %}
 
     {% for item in items %}
       {%
@@ -58,7 +60,7 @@
       {% set title = item.title %}
       {% set id = (parent_id ~ '-item-' ~ loop.index)|clean_id %}
 
-      <li{{ item.attributes.addClass(classes) }}>
+      {% if menu_level != 0 %}<li{{ item.attributes.addClass(classes) }}>{% endif %}
 
         {#
           Progressive enhancement: make sure there is always a menu entry.
@@ -103,10 +105,8 @@
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
 
         {% endif %}
-
-      </li>
-
-    {% endfor %}
-    </ul>
+        {% if menu_level != 0 %}</li>{% endif %}
+      {% endfor %}
+    {% if menu_level != 0 %}</ul>{% endif %}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description

Improves screen reader performance by eliminating redundancies, or consolidating relevant properties. The results mean the screen reader announces far fewer words, while still announcing all the important roles and labels.

### Global Header menus

Each navigation section used to have a visually-hidden heading referenced with `aria-labelledby`. That markup caused every heading to effectively be announced twice (once for `aria-labelledby` and once for the heading itself). All of the headings have been removed, and the `aria-label` attribute is used in place of `aria-labelledby`, with Twig-translated strings as each label. The labels were chosen to be very short, with the assumption that the word "navigation" gets read afterwards:

| Entering | Leaving |
|:--|:--|
| "Language, navigation" | "end of, Language, navigation" |
| "Help, navigation" | "end of, Help, navigation" |
| "Account, navigation" | "end of, Account, navigation" |

### Help/Account menus

The other two menus in the Global Header are identical in structure to each other, and both always render as a dropdown whose button used to be the only top-level item of a two-level nested list.

Their templates were modified to eliminate the top-level `<ul><li>` surrounding the toggle buttons. If the menu has no descendant items, the `<ul>` will not be rendered at all. With the list and list-items removed around the toggle button, the screen reader thus announces two fewer items before offering the user the chance to open the dropdown, and a total of three announcements were removed if the person wishes to pass by the menu completely.

- Help, navigation
- ✂️ ~List, 1 item~
- ✂️ ~List item 1 of 1~
- Help menu pop up button
- _[if you open the menu, it will begin a new list and go through each item]_
- ✂️ ~end of list~
- end of, Help, navigation

### Site logo

It now announces the same in mobile/desktop by marking the image tag as hidden. In its place we have `visually-hidden` text of the site name.

### Landmark roles

Header/Main/Footer are all marked up identically now, with `aria-label` piped through Twig translation. Sidebars retain their `complementary` roles (no `aria-label` present).

### Footer

- Footer/Social nav are now `<nav>` with explicit `aria-label` translated by Twig. visually-hidden headings have been removed.
- OCHA Mandate avoids announcing "Sketch. empty artbox" and the SVG will now read as the full-text of UN-OCHA spelled out.
- Copyright notice has a header to announce it now.


## Steps to reproduce the problem or Steps to test

  1. Use the OS, browser, and screen reader of your choice. For testing purposes, you might want to slow down the speech in your OS settings.
  1. Enable the screen reader and give the page a refresh to start from the beginning.
  1. Compare readout to notes above, and to [production](https://web.brand.unocha.org/)
  
## Impact
No breaking changes expected. However, without some manual modification, existing sites may not receive all the benefits  contained in this PR:

- If any of the block/links/menu templates for the relevant menus were overridden, the changes in this PR should be incorporated. Detailed procedures or advice can be given on a case-by-case basis.
- If `block--system-branding-block.html.twig` was overridden, its changes need to be incorporated.
- If any of the `page.html.twig` variants exist, they will need some attributes added to match the base-theme. Same for maintenance page.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have made changes to the sub theme to reflect those in the base theme
