### PR TITLE
CD-475 Mobile logo in subtheme follow-up

### DIFF
--- a/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -31,7 +31,7 @@ global-styling:
 cd-header:
   css:
     theme:
-      components/cd/cd-header/cd-logo.css
+      components/cd/cd-header/cd-logo.css: {}
 
 ###
 # Define Drupal libraries for additional webfonts.

--- a/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -11,7 +11,6 @@ global-styling:
     base:
       css/brand.css: {}
       css/styles.css: {}
-#     theme:
 #   dependencies:
 #     - common_design_subtheme/custom-teaser
 


### PR DESCRIPTION
## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
A follow-up PR to https://github.com/UN-OCHA/common_design/pull/396
Had I tested it properly before approving, I would have caught this :)
The lack of `: {}` after `components/cd/cd-header/cd-logo.css` results in an error in the browser ` Warning: foreach() argument must be of type array|object, string given in /srv/www/html/core/lib/Drupal/Core/Asset/LibraryDiscoveryParser.php on line 179`

The other change - removing the `theme` style type - has no effect as it was commented out, but I think the intention was to replace `theme` with `base`.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have made changes to the sub theme to reflect those in the base theme
