### PR TITLE
[CD-418] improve a11y/RTL of CD Tabs

### DIFF
--- a/components/cd-tabs/cd-tabs.css
+++ b/components/cd-tabs/cd-tabs.css
@@ -1,82 +1,76 @@
 /**
  * CD Tabs
+ *
+ * They form full-width buttons on mobile, and a wrappable row of auto-width
+ * buttons once space allows. They work with all reading directions.
  */
 
+:root {
+  --cd-tabs-border-width: 2px;
+}
+
+/**
+ * Mobile tabs (default)
+ */
 ul.tabs {
-  display: block;
+  display: flex;
+  flex-flow: row wrap;
   margin: 1rem 0 2rem;
   padding: 0;
   list-style: none;
-  border-bottom: 2px solid var(--brand-grey);
-}
-
-/* Clearfix */
-ul.tabs::after {
-  display: block;
-  visibility: hidden;
-  clear: both;
-  height: 0;
-  content: ".";
+  border-bottom: var(--cd-tabs-border-width) solid var(--brand-grey);
 }
 
 ul.tabs > li {
   display: block;
+  flex: 0 0 100%;
+  align-self: flex-end;
   margin: 0;
+  margin-bottom: calc(var(--cd-tabs-border-width) * -1);
 }
 
 ul.tabs > li > a {
-  position: relative;
   display: block;
   margin: 0;
-  padding: 0.25rem 1rem;
+  padding: 0.5rem 1rem;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
   color: var(--brand-primary--dark);
   border: 0 none;
-  border-bottom: 2px solid var(--brand-grey);
+  border-bottom: var(--cd-tabs-border-width) solid var(--brand-grey);
   border-radius: 0;
   background: none;
   font-weight: 700;
 }
 
-@media (min-width: 576px) {
-  ul.tabs > li {
-    position: relative;
-    /* Height of border bottom. */
-    margin-bottom: -2px;
-  }
-
-  [dir="ltr"] ul.tabs > li {
-    float: left;
-    margin-right: 0.5rem;
-  }
-
-  [dir="rtl"] ul.tabs > li {
-    float: right;
-    margin-left: 0.5rem;
-  }
-}
-
-@media (min-width: 768px) {
-  ul.tabs > li > a {
-    min-width: 7rem; /* 112px */
-  }
-}
-
 ul.tabs > li > a.is-active,
 ul.tabs > li > a:hover {
   color: var(--brand-primary);
-  border: 0 none !important;
-  border-bottom: 2px solid var(--brand-grey) !important;
   background-color: var(--brand-grey);
 }
 
-ul.tabs > li > a.is-active {
-  background-color: var(--cd-grey--light);
+ul.tabs > li > a:focus {
+  color: var(--cd-white);
+  outline: 3px solid var(--brand-highlight);
+  background: var(--brand-primary--dark);
 }
 
-ul.tabs > li > a:focus {
-  outline: 3px solid var(--brand-primary--light);
-  background: var(--brand-grey);
+/**
+ * Standard tabs.
+ *
+ * Once we have enough room, expand tabs to a wrappable row and remove borders.
+ */
+@media (min-width: 576px) {
+  ul.tabs {
+    gap: 0.5rem;
+  }
+  ul.tabs > li {
+    flex-basis: auto;
+    margin-bottom: 0;
+  }
+  ul.tabs > li > a {
+    padding: 0.25rem 1rem;
+    border-bottom: 0;
+  }
 }

--- a/components/cd-tabs/cd-tabs.html
+++ b/components/cd-tabs/cd-tabs.html
@@ -4,18 +4,15 @@
 <div class="cd-page-layout-container">
   <div class="cd-container">
 
-    <nav class="tabs" role="navigation" aria-label="Tabs">
-
-      <h2 class="visually-hidden">Primary tabs</h2>
-      <ul class="tabs primary">
+    <nav class="tabs" aria-label="Primary tabs">
+      <ul class="tabs primary" role="list">
         <li class="is-active">
-          <a href="#" class="is-active">View<span class="visually-hidden">(active tab)</span></a>
+          <a href="#" class="is-active">View<span class="visually-hidden"> (active tab)</span></a>
         </li>
         <li><a href="#">Edit</a></li>
         <li><a href="#">Settings</a></li>
         <li><a href="#">Delete</a></li>
       </ul>
-
     </nav>
 
   </div>

--- a/components/cd-tabs/cd-tabs.html.twig
+++ b/components/cd-tabs/cd-tabs.html.twig
@@ -1,10 +1,9 @@
 {{ attach_library('common_design/cd-tabs') }}
 
-<nav class="tabs" role="navigation" aria-label="Tabs">
-  <h2 class="visually-hidden">Primary tabs</h2>
-  <ul class="tabs primary">
+<nav class="tabs" aria-label="{{ 'Primary tabs'|t }}">
+  <ul class="tabs primary" role="list">
     <li class="is-active">
-      <a href="#" class="is-active">View<span class="visually-hidden">(active tab)</span></a>
+      <a href="#" class="is-active">View<span class="visually-hidden"> (active tab)</span></a>
     </li>
     <li><a href="#">Edit</a></li>
     <li><a href="#">Settings</a></li>

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -5,19 +5,20 @@
  *
  * Available variables:
  * - primary: HTML list items representing primary tasks.
- * - secondary: HTML list items representing primary tasks.
+ * - secondary: HTML list items representing secondary tasks.
  *
  * Each item in these variables (primary and secondary) can be individually
  * themed in menu-local-task.html.twig.
  */
 #}
-
 {{ attach_library('common_design/cd-tabs') }}
-{% if primary %}
-  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  <ul class="tabs primary">{{ primary }}</ul>
-{% endif %}
-{% if secondary %}
-  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
-  <ul class="tabs secondary">{{ secondary }}</ul>
-{% endif %}
+{% set aria_label = primary ? 'Primary actions'|t : 'Secondary actions'|t %}
+
+<nav aria-label="{{ aria_label }}">
+  {% if primary %}
+    <ul class="tabs primary" role="list">{{ primary }}</ul>
+  {% endif %}
+  {% if secondary %}
+    <ul class="tabs secondary" role="list">{{ secondary }}</ul>
+  {% endif %}
+</nav>


### PR DESCRIPTION
Refs: CD-418, CD-478

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
For RWR I had revamped the tabs to use flexbox which brings automatic RTL support. For CD-476 I improved the screen reading of many navigational areas, and settled on a pattern that results in an informative but less verbose screen reading. This is a contribution from those two efforts.

The tabs look largely the same, but are spaced a bit more tightly in desktop (more tabs possible in same area), and taller on mobile (larger hit targets)

## Steps to reproduce the problem or Steps to test

  1. Load the branch and inspect some tabs at various viewport widths, e.g. by logging in and viewing a node
  1. Use a screen reader. When the tabs are reached, the reader should say:
    - Primary actions, navigation
    - List, X items
    - visited link, View (active tab), item 1 of X...
    - end of list
    - end of, Primary actions, navigation

I've also [tested this on RWR](https://github.com/UN-OCHA/response-site/compare/develop...cd-418) which has separate primary/secondary tabs and they both announced correctly in different areas of the page. The Twig template checks if `primary` is available and always says primary if it can (including if both are output, which is possible via Block config). Other wise it says secondary when `primary` is totally absent.
  
## Impact
No impact. RWR a special case because we replaced the old CD Tabs component with its own version that was the basis for this PR. However the upgrade isn't urgent because RWR will swap out whatever version of CD Tabs it finds with its own. Either way, I will handle that upgrade once this change is tagged in a release.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.

@left23 just an FYI I finally circled back to this!