### PR TITLE
fix: prevent CD Form from applying outside <form> elements

### DIFF
--- a/components/cd-form/README.md
+++ b/components/cd-form/README.md
@@ -1,26 +1,19 @@
 # Form
 
 ## Purpose and Usage
-CSS-only component for basic form element styles.
-The current approach is defaulting to browser styles with some CD styles added over
-time as we work on consistency with other properties (RW, HID).
-This means we don't expect it to look the same across every browser.
+CSS-only component for basic form element styles. The current approach is defaulting to browser styles with some CD styles added over time as we work on consistency with other properties (RW, HID). This means we don't expect it to look the same across every browser.
 
 Also endeavour to keep this devoid of rules that have implication to layout,
-where possible.
-
-This can expand as needed. Currently, there are generic and Drupal-specific
-selectors.
+where possible. This can expand as needed. Currently, there are generic and Drupal-specific selectors.
 
 @TODO spinner as component.
 @TODO reinstate webkit search cancel button (currently disabled in normalise.css line 366)
 
 ## Caveats
-This component uses the `cd-flow` component for vertical rhythm.
-The base theme provides some template overrides to add classes to Drupal forms
-There is special styling and spacing for the Drupal user pages.
-The `--cd-flow-space` variable value should be adjusted as needed.
-e.g.
+
+All form elements MUST be inside `<form>` to be affected.
+
+This component uses the `cd-flow` component for vertical rhythm. The base theme provides some template overrides to add classes to Drupal forms. There is special styling and spacing for the Drupal user pages. The `--cd-flow-space` variable value should be adjusted as needed, e.g.
 
 ```css
 /* Form styles for Drupal User forms */

--- a/components/cd-form/cd-form.css
+++ b/components/cd-form/cd-form.css
@@ -6,17 +6,17 @@
  * or as a last resort modifying the selectors to match the markup of your form.
  */
 
-input[type="text"],
-input[type="number"],
-input[type="password"],
-input[type="email"],
-input[type="search"],
-input[type="tel"],
-input[type="url"],
-input[type="date"],
-input[type="time"],
-input[type="file"],
-textarea {
+form input[type="text"],
+form input[type="number"],
+form input[type="password"],
+form input[type="email"],
+form input[type="search"],
+form input[type="tel"],
+form input[type="url"],
+form input[type="date"],
+form input[type="time"],
+form input[type="file"],
+form textarea {
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
@@ -27,7 +27,7 @@ textarea {
   font-size: 1rem;
 }
 
-select {
+form select {
   width: 100%;
   max-width: 100%;
   padding: 0.5rem 0.75rem;
@@ -35,72 +35,31 @@ select {
   font-size: 1rem;
 }
 
-textarea {
+form textarea {
   resize: vertical;
   /* Better readability similar to paragraphs. */
   line-height: 1.5;
 }
 
 @media (min-width: 576px) {
-  input[type="date"],
-  input[type="time"],
-  select {
+  form input[type="date"],
+  form input[type="time"],
+  form select {
     width: auto;
   }
 }
 
 @media (min-width: 768px) {
-  input[type="text"],
-  input[type="number"],
-  input[type="password"],
-  input[type="email"],
-  input[type="search"],
-  input[type="tel"],
-  input[type="url"],
-  input[type="file"] {
+  form input[type="text"],
+  form input[type="number"],
+  form input[type="password"],
+  form input[type="email"],
+  form input[type="search"],
+  form input[type="tel"],
+  form input[type="url"],
+  form input[type="file"] {
     max-width: 50ch;
   }
-}
-
-label,
-fieldset legend,
-.label {
-  display: block;
-  color: var(--cd-black);
-  font-weight: 700;
-}
-
-input.error,
-textarea.error,
-select.error {
-  border-color: var(--cd-highlight-red);
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  outline: 3px solid var(--brand-primary);
-  outline-offset: -2px;
-}
-
-input::-webkit-input-placeholder {
-  color: var(--cd-grey--dark);
-  font-style: italic;
-}
-
-input:-ms-input-placeholder {
-  color: var(--cd-grey--dark);
-  font-style: italic;
-}
-
-input::-webkit-search-cancel-button {
-  position: relative;
-  right: 10px;
-}
-
-/* Safari fix */
-input::-webkit-search-decoration {
-  -webkit-appearance: none;
 }
 
 form fieldset {
@@ -109,9 +68,51 @@ form fieldset {
   padding: 0;
   border: none;
 }
+
 form fieldset legend {
   margin: 0;
   padding: 0;
+}
+
+form label,
+form fieldset legend,
+form .label {
+  display: block;
+  color: var(--cd-black);
+  font-weight: 700;
+}
+
+form input.error,
+form textarea.error,
+form select.error {
+  border-color: var(--cd-highlight-red);
+}
+
+form input:focus,
+form select:focus,
+form textarea:focus {
+  outline: 3px solid var(--brand-primary);
+  outline-offset: -2px;
+}
+
+form input::-webkit-input-placeholder {
+  color: var(--cd-grey--dark);
+  font-style: italic;
+}
+
+form input:-ms-input-placeholder {
+  color: var(--cd-grey--dark);
+  font-style: italic;
+}
+
+form input::-webkit-search-cancel-button {
+  position: relative;
+  right: 10px;
+}
+
+/* Safari fix */
+form input::-webkit-search-decoration {
+  -webkit-appearance: none;
 }
 
 .cd-form {


### PR DESCRIPTION
# CD-473

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
We had some collisions with [Admin Toolbar](https://www.drupal.org/project/admin_toolbar) and decided the easiest thing to do is prefix our selectors with `form`. All of our use-cases for this component involve true `<form>`s so it seems to be a safe modification.

## Steps to reproduce the problem or Steps to test

  1. Test on a Drupal install that uses forms (CD Demo, Sesame, RW)
  1.
  1.
  
  
## Impact
We increased specificity so any CSS overrides might need to be adjusted. Simply add `form` to the selector in the appropriate location and the override will again take effect.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
