### PR TITLE
[CD-408] disable animations/transitions when unwanted

### DIFF
--- a/components/cd/cd-resets/cd-resets.css
+++ b/components/cd/cd-resets/cd-resets.css
@@ -48,3 +48,36 @@ body.no-scroll {
   padding: 0;
   list-style: none;
 }
+
+/**
+ * Respect user prefs for animations/transitions
+ *
+ * Some people prefer not to see animations/transitions for medical or personal
+ * reasons. Additionally it can happen that the browser is unable to draw the
+ * animations at a sufficient speed.
+ *
+ * This block of rules will wholesale disable the animations when unwanted,
+ * leaving the codebase to implement its animations/transitions in a simple
+ * format without individual rules needing to be qualified.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  * {
+    /* turn animations on if user doesn't mind */
+    animation-play-state: running;
+  }
+}
+
+@media not (update: fast) {
+  * {
+    /* turn them off again if the browser can't draw them effectively */
+    animation-play-state: paused;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    /* explicitly disable animations and transitions when requested */
+    transition-duration: 0s !important;
+    animation-play-state: paused;
+  }
+}


### PR DESCRIPTION
# CD-408

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- :heavy_check_mark: New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Either user preference, or browser resources can cause animations and transitions to be disabled.

## Steps to reproduce the problem or Steps to test

  1. Enable `prefers-reduced-motion: reduce` in your browser
  1. Mouse over buttons to see if the transitions are eliminated
  
## Impact
- No change to browsers with `prefers-reduced-motion: no-preference` (the default).
- Browsers with `prefers-reduced-motion: reduce` will actually see that preference respected now.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
