### PR TITLE
fix(a11y): disable animations/transitions of pseudo-elements

### DIFF
--- a/components/cd/cd-resets/cd-resets.css
+++ b/components/cd/cd-resets/cd-resets.css
@@ -61,21 +61,27 @@ body.no-scroll {
  * format without individual rules needing to be qualified.
  */
 @media (prefers-reduced-motion: no-preference) {
-  * {
+  *,
+  *::before,
+  *::after {
     /* turn animations on if user doesn't mind */
     animation-play-state: running;
   }
 }
 
 @media not (update: fast) {
-  * {
+  *,
+  *::before,
+  *::after {
     /* turn them off again if the browser can't draw them effectively */
     animation-play-state: paused;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *,
+  *::before,
+  *::after {
     /* explicitly disable animations and transitions when requested */
     transition-duration: 0s !important;
     animation-play-state: paused;


### PR DESCRIPTION
The previous rules still left parts of the main nav with visual transitions. Including pseudo-elements in the motion block will truly disable everything.

Refs: CD-408, 1acbe62, #408 

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!--- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Follow-up to #408 

## Steps to reproduce the problem or Steps to test

  1. Use keyboard nav for main nav with `prefers-reduced-motion: reduce`
  
## Impact
No impact.

## PR Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
