### PR TITLE
[CD-481] card image gaps, ARIA roles, demo tweaks

### DIFF
--- a/components/cd-article/cd-article.html
+++ b/components/cd-article/cd-article.html
@@ -41,7 +41,7 @@
 
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--first" role="complementary">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--first">
           <p>This is a sidebar in the article element.</p>
 
           <div class="cd-block">
@@ -104,7 +104,7 @@
 
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact">
           <p>This is a sidebar in the article element.</p>
 
           <div class="cd-block">

--- a/components/cd-article/cd-article.html.twig
+++ b/components/cd-article/cd-article.html.twig
@@ -38,7 +38,7 @@
 
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">
         <p>This is a sidebar in the article element.</p>
 
         <div class="cd-block">
@@ -101,7 +101,7 @@
 
 			</div>
 
-			<aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact" role="complementary">
+			<aside class="cd-layout__sidebar cd-layout__sidebar--first cd-content--compact">
 				<p>This is a sidebar in the article element.</p>
 
 				<div class="cd-block">

--- a/components/cd-article/cd-article.html.twig
+++ b/components/cd-article/cd-article.html.twig
@@ -38,7 +38,7 @@
 
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
         <p>This is a sidebar in the article element.</p>
 
         <div class="cd-block">

--- a/components/cd-card/cd-card.css
+++ b/components/cd-card/cd-card.css
@@ -21,6 +21,7 @@
  * Card image
  */
 .cd-card__image img {
+  display: block;
   width: 100%;
   height: 13rem;
 }

--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -128,9 +128,9 @@
           {{ content }}
 {#        </div>#}
 
-{#        <div class="cd-layout__sidebar cd-layout__sidebar--first" role="complementary">#}
+{#        <aside class="cd-layout__sidebar cd-layout__sidebar--first">#}
 {#          Other fields on the node can be printed here to create a faux sidebar layout.#}
-{#        </div>#}
+{#        </aside>#}
 
 {#      </div>#}
 {#    {% endblock %}#}

--- a/templates/layout/page--facets.html.twig
+++ b/templates/layout/page--facets.html.twig
@@ -22,7 +22,7 @@
             NOTE: Enabling Twig debug means the div is no longer empty.
             @see https://www.drupal.org/project/drupal/issues/953034
           #}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first">{{ page.facets }}{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -90,7 +90,7 @@
             NOTE: Enabling Twig debug means the div is no longer empty.
             @see https://www.drupal.org/project/drupal/issues/953034
           #}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first" role="complementary">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--first">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">
@@ -98,7 +98,7 @@
         </div>{# /.cd-layout__content #}
 
         {% if page.sidebar_second %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ page.sidebar_second }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_second }}</aside>
         {% endif %}
       </div>
 


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
There used to be a little gap under every Card image. By setting the image to `display:block` we eliminate that gap. Now the visual appearance will match whatever you wrote in code. That is, if you have a flex `gap:1rem`, and a Card container `padding-top:1rem` then it will truly be 2rem instead of a little extra.

## Steps to reproduce the problem or Steps to test

  1. Check the demo

Before / after, with Flex item borders overlaid.

<img width="393" alt="CD-481-1-before" src="https://github.com/UN-OCHA/common_design/assets/254753/580edbac-aa6b-401d-a49b-76bd51cdc1c6"> <img width="392" alt="CD-481-2-after" src="https://github.com/UN-OCHA/common_design/assets/254753/e459fc94-715f-4203-9e5b-c937761d5bcf">

## Impact
If you relied on an image to be `display:initial` (inline content) then you might have to enforce that explicitly now. Most cards should be unaffected since they use Flex by default.

```css
.cd-card__image img {
  display: initial;
}
```

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
