### PR TITLE
[CD-486] Ensure tab order of Global Header matches visual order

### DIFF
--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -66,10 +66,6 @@ cd-user-menu:
   dependencies:
     - common_design/cd-dropdown
 
-cd-ocha-services:
-  js:
-    js/cd-ocha-services.js: {}
-
 cd-resets:
   css:
     base:
@@ -89,6 +85,8 @@ cd-header:
       components/cd/cd-header/cd-nav.css: {}
       components/cd/cd-header/cd-search.css: {}
       components/cd/cd-header/cd-search--inline.css: {}
+  js:
+    components/cd/cd-header/cd-ocha-services.js: {}
   dependencies:
     - common_design/cd-user-menu
 

--- a/components/cd/cd-header/cd-ocha-services.js
+++ b/components/cd/cd-header/cd-ocha-services.js
@@ -16,7 +16,7 @@
       if (section && sibling) {
         // Ensure the element is hidden before moving it to avoid flickering.
         this.toggleVisibility(section, true);
-        sibling.parentNode.insertBefore(section, sibling.nextSibling);
+        sibling.parentNode.insertBefore(section, sibling);
       }
     },
 

--- a/components/cd/cd-header/cd-ocha-services.js
+++ b/components/cd/cd-header/cd-ocha-services.js
@@ -9,7 +9,7 @@
 
     /**
      * Hide and move OCHA Services to the top of the header after the target.
-   */
+     */
     moveToHeader: function (id, target) {
       var section = document.getElementById(id);
       var sibling = document.getElementById(target);

--- a/templates/cd/cd-footer/cd-footer.html.twig
+++ b/templates/cd/cd-footer/cd-footer.html.twig
@@ -4,8 +4,6 @@
  * Top-level template for CD Footer.
  */
 #}
-{{ attach_library('common_design/cd-ocha-services') }}
-
 <footer class="cd-footer" aria-label="{{ 'Site footer'|t }}">
   <div class="cd-container cd-footer__inner">
 


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Reported to us in #413. Fixes #413.

## Steps to reproduce the problem or Steps to test

  1. Load branch and tab through document from the beginning.
  2. Without the PR, OCHA Services gets highlighted after language, help, user menus.
  3. After PR, OCHA Services is highlighted first.

## Impact
No impact. The changed function is private to the base-theme Drupal behaviors.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
