### PR TITLE
[CD-487] collapse mandate to two lines in EN

### DIFF
--- a/components/cd/cd-footer/cd-footer-mandate.css
+++ b/components/cd/cd-footer/cd-footer-mandate.css
@@ -22,7 +22,7 @@
 
 .cd-mandate__text {
   display: block;
-  max-width: 540px;
+  max-width: 550px;
   margin: 0 auto;
   padding: 0 var(--cd-container-padding);
 }


### PR DESCRIPTION
# CD-487

Other translations wrap to three real lines but EN had a two-letter orphan on the third line. This looks nicer.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
