### PR TITLE
[CD-489] CD Dropdown example and README

### DIFF
--- a/components/cd-dropdown/README.md
+++ b/components/cd-dropdown/README.md
@@ -1,13 +1,7 @@
-# Dropdown
-A vanilla javascript replacement for Bootstrap’s dropdown plugin (used in
-ocha_basic Drupal 7, jquery-dependent).
+# CD Dropdown
 
 There are two elements: the button (referred to in code as “toggler”) and the
-dropdown (referred to as “element”).
-The dropdown element needs to be included in the markup and requires the
-attribute of data-cd-toggable.
-We use javascript to create and remove the toggle button as needed and the
-attribute data-cd-hidden to apply the display rules.
+dropdown (referred to as “element”). The dropdown element needs to be included in the markup and requires the attribute of data-cd-toggable. We use javascript to create and remove the toggle button as needed and the attribute data-cd-hidden to apply the display rules.
 
 @TODO refine this based on
 https://docs.google.com/document/d/1GpTtCWNQvGiPDfZmhFvaKGvU9hbOG0HedFTYgo3nvd4/edit#heading=h.w6466tbgvgf1
@@ -24,22 +18,16 @@ The following attributes should be added to the dropdown element’s markup:
 
 **Optional**
 - `data-cd-logo` and/or `data-cd-icon` if either are required for the button
-- `data-cd-logo-only` adds a class visually-hidden to the button label
+- `data-cd-logo-only` adds a class `visually-hidden` to the button label
 - `data-cd-label-switch` for different labels depending on open/closed state
-- `data-cd-focus-target` for adding focus to a specific element when dropdown
-is toggled (this works well with the Search component. Add the ID of the search
-input field and it will have focus when the dropdown is expanded)
-- `data-cd-replace=”ID”` will replace the element with the given ID with a
-toggler. The element (ex:  a link) serves as a fallback element for progressive
-enhancement when the cd-dropdown script cannot run.
-- `data-cd-insert-after` will insert the button after the toggable element. This
-can be used for "show more" type buttons.
-
+- `data-cd-focus-target` for adding focus to a specific element when dropdown is toggled (this works well with the Search component. Add the ID of the search input field and it will have focus when the dropdown is expanded)
+- `data-cd-replace=”ID”` will replace the element with the given ID with a toggler. The element (ex:  a link) serves as a fallback element for progressive enhancement when the cd-dropdown script cannot run.
+- `data-cd-insert-after` will insert the button after the toggable element. This can be used for "show more" type buttons.
 
 ## Caveats
+
 Implementation for Drupal required using Drupal behaviours so we use the file
-in `common_design/js` for the base theme.
-The JS in this component folder is for testing outside of Drupal.
+in `common_design/js` for the base theme. The JS in this component folder is for testing outside of Drupal.
 
 The dropdown element must be wrapped in a parent element.
 

--- a/components/cd-dropdown/cd-dropdown.html.twig
+++ b/components/cd-dropdown/cd-dropdown.html.twig
@@ -1,8 +1,8 @@
 <div class="cd-layout cd-dropdown-showmore-example">
   <div class="cd-layout__content">
     <h3>CD Dropdown: Show More</h3>
-    <p>Lorem ipsum sit deserunt ut in qui consequat dolore labore exercitation. Ut quis incididunt in dolore pariatur aute adipisicing duis elit pariatur ut. Labore et sint elit enim ut ullamco ad magna ex qui nostrud officia sed aliquip sint do aliqua exercitation mollit nulla nostrud enim labore reprehenderit esse occaecat ea non ex.</p>
-    <p>Anim do laboris eu exercitation minim aliquip amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
+    <p>The first two paragraphs of content will always display, no matter the state of the button.</p>
+    <p>The remaining content below this paragraph tag is wrapped in an element with an ID, which acts as the togglable section of content. The data-attributes are configured to display the button <em>after</em> the content, with labels fully translatable by Twig and so forth.</p>
     <div id="cd-dropdown-showmore-example"
       data-cd-toggable="{{ 'Show full content'|t }}"
       data-cd-toggable-expanded="{{ 'Hide full content'|t }}"
@@ -12,7 +12,7 @@
       data-cd-component="cd-dropdown-showmore-example"
       data-cd-replace="keep"
     >
-      <p>Amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
+      <p>This is expanded content that was revealed by pressing the <strong>{{ 'Show full content'|t }}</strong> button.</p>
       <p>Exercitation consectetur irure ea et dolor id eiusmod nostrud fugiat in sit ex ea culpa magna sit excepteur ullamco duis voluptate ullamco sed do laborum ut exercitation laborum irure aliquip sunt ullamco reprehenderit commodo elit ea magna ex ea ut aliqua dolore incididunt dolore mollit labore amet laboris amet nulla ea sint amet do eiusmod do adipisicing voluptate proident ad magna qui in cupidatat ea incididunt anim pariatur eiusmod ut eu anim ad pariatur ex dolore ad dolor exercitation aliqua occaecat qui aute dolor excepteur non cupidatat et magna voluptate velit magna velit dolore enim duis ea occaecat dolore ut ea irure est anim fugiat enim commodo officia elit in voluptate ad quis officia ad cupidatat ut enim anim non anim nulla id anim in esse amet occaecat proident voluptate in adipisicing ullamco dolor culpa labore in eiusmod est adipisicing deserunt in eiusmod consequat officia labore ut dolor sint elit consectetur pariatur anim duis laborum sit est nulla in anim irure qui fugiat in eiusmod dolor sed est veniam officia enim dolore dolore sed sit aliqua voluptate ullamco dolore exercitation ea eu et sunt velit officia cillum velit ullamco anim sint et nisi.</p>
       <p>Aute cupidatat eu ullamco dolore ad nisi incididunt dolor in ut irure reprehenderit velit officia officia est est nostrud. In labore sunt aliqua dolor duis in laborum laborum ullamco proident anim est pariatur enim dolore veniam dolore non et commodo anim in amet aliqua ex laboris anim esse.</p>
     </div>

--- a/components/cd-dropdown/cd-dropdown.html.twig
+++ b/components/cd-dropdown/cd-dropdown.html.twig
@@ -3,47 +3,19 @@
     <h3>CD Dropdown: Show More</h3>
     <p>Lorem ipsum sit deserunt ut in qui consequat dolore labore exercitation. Ut quis incididunt in dolore pariatur aute adipisicing duis elit pariatur ut. Labore et sint elit enim ut ullamco ad magna ex qui nostrud officia sed aliquip sint do aliqua exercitation mollit nulla nostrud enim labore reprehenderit esse occaecat ea non ex.</p>
     <p>Anim do laboris eu exercitation minim aliquip amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
-    <div id="cd-dropdown-showmore-example">
+    <div id="cd-dropdown-showmore-example"
+      data-cd-toggable="{{ 'Show full content'|t }}"
+      data-cd-toggable-expanded="{{ 'Hide full content'|t }}"
+      data-cd-toggable-keep=""
+      data-cd-insert-after=""
+      data-cd-icon="arrow-down"
+      data-cd-component="cd-dropdown-showmore-example"
+      data-cd-replace="keep"
+    >
       <p>Amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
       <p>Exercitation consectetur irure ea et dolor id eiusmod nostrud fugiat in sit ex ea culpa magna sit excepteur ullamco duis voluptate ullamco sed do laborum ut exercitation laborum irure aliquip sunt ullamco reprehenderit commodo elit ea magna ex ea ut aliqua dolore incididunt dolore mollit labore amet laboris amet nulla ea sint amet do eiusmod do adipisicing voluptate proident ad magna qui in cupidatat ea incididunt anim pariatur eiusmod ut eu anim ad pariatur ex dolore ad dolor exercitation aliqua occaecat qui aute dolor excepteur non cupidatat et magna voluptate velit magna velit dolore enim duis ea occaecat dolore ut ea irure est anim fugiat enim commodo officia elit in voluptate ad quis officia ad cupidatat ut enim anim non anim nulla id anim in esse amet occaecat proident voluptate in adipisicing ullamco dolor culpa labore in eiusmod est adipisicing deserunt in eiusmod consequat officia labore ut dolor sint elit consectetur pariatur anim duis laborum sit est nulla in anim irure qui fugiat in eiusmod dolor sed est veniam officia enim dolore dolore sed sit aliqua voluptate ullamco dolore exercitation ea eu et sunt velit officia cillum velit ullamco anim sint et nisi.</p>
       <p>Aute cupidatat eu ullamco dolore ad nisi incididunt dolor in ut irure reprehenderit velit officia officia est est nostrud. In labore sunt aliqua dolor duis in laborum laborum ullamco proident anim est pariatur enim dolore veniam dolore non et commodo anim in amet aliqua ex laboris anim esse.</p>
     </div>
-
-    <script>
-      (function iife() {
-        'use strict';
-
-        /**
-         * Hide long content.
-         *
-         * This script is inline, so that the attributes appear in the DOM
-         * before the CD Dropdown script runs during DOMContentLoaded. In doing
-         * so, we "dynamically" create the conditions for the dropdown on any
-         * length of content (which is unknown since it comes out of Drupal).
-         *
-         * If there are more elements than CONTENT_ELEMENT_LIMIT allows, we only
-         * display the first few, and add a toggling button to show the rest.
-         */
-        var content = document.getElementById('cd-dropdown-showmore-example');
-        var children = content.childNodes;
-        var count = 0;
-        for (var i = 0, l = children.length; i < l; i++) {
-          if (children[i].nodeType === 1) {
-            count++;
-          }
-        }
-
-        if (count) {
-          content.setAttribute('data-cd-toggable', 'Show full content');
-          content.setAttribute('data-cd-toggable-expanded', 'Hide full content');
-          content.setAttribute('data-cd-toggable-keep', '');
-          content.setAttribute('data-cd-insert-after', '');
-          content.setAttribute('data-cd-icon', 'arrow-down');
-          content.setAttribute('data-cd-component', 'cd-dropdown-showmore-example');
-          content.setAttribute('data-cd-replace', 'keep');
-        }
-      }());
-    </script>
   </div>
 
   <aside class="cd-layout__sidebar cd-layout__sidebar--wide">

--- a/components/cd-dropdown/cd-dropdown.html.twig
+++ b/components/cd-dropdown/cd-dropdown.html.twig
@@ -1,0 +1,54 @@
+<div class="cd-layout cd-dropdown-showmore-example">
+  <div class="cd-layout__content">
+    <h3>CD Dropdown: Show More</h3>
+    <p>Lorem ipsum sit deserunt ut in qui consequat dolore labore exercitation. Ut quis incididunt in dolore pariatur aute adipisicing duis elit pariatur ut. Labore et sint elit enim ut ullamco ad magna ex qui nostrud officia sed aliquip sint do aliqua exercitation mollit nulla nostrud enim labore reprehenderit esse occaecat ea non ex.</p>
+    <p>Anim do laboris eu exercitation minim aliquip amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
+    <div id="cd-dropdown-showmore-example">
+      <p>Amet culpa in nisi et quis id ex consequat minim amet sed deserunt consectetur eu in cupidatat eiusmod pariatur eiusmod exercitation veniam sunt enim labore dolor ut reprehenderit quis elit non sit incididunt in incididunt velit aliqua est veniam do sint ad reprehenderit voluptate do aute aliquip veniam laborum ullamco elit</p>
+      <p>Exercitation consectetur irure ea et dolor id eiusmod nostrud fugiat in sit ex ea culpa magna sit excepteur ullamco duis voluptate ullamco sed do laborum ut exercitation laborum irure aliquip sunt ullamco reprehenderit commodo elit ea magna ex ea ut aliqua dolore incididunt dolore mollit labore amet laboris amet nulla ea sint amet do eiusmod do adipisicing voluptate proident ad magna qui in cupidatat ea incididunt anim pariatur eiusmod ut eu anim ad pariatur ex dolore ad dolor exercitation aliqua occaecat qui aute dolor excepteur non cupidatat et magna voluptate velit magna velit dolore enim duis ea occaecat dolore ut ea irure est anim fugiat enim commodo officia elit in voluptate ad quis officia ad cupidatat ut enim anim non anim nulla id anim in esse amet occaecat proident voluptate in adipisicing ullamco dolor culpa labore in eiusmod est adipisicing deserunt in eiusmod consequat officia labore ut dolor sint elit consectetur pariatur anim duis laborum sit est nulla in anim irure qui fugiat in eiusmod dolor sed est veniam officia enim dolore dolore sed sit aliqua voluptate ullamco dolore exercitation ea eu et sunt velit officia cillum velit ullamco anim sint et nisi.</p>
+      <p>Aute cupidatat eu ullamco dolore ad nisi incididunt dolor in ut irure reprehenderit velit officia officia est est nostrud. In labore sunt aliqua dolor duis in laborum laborum ullamco proident anim est pariatur enim dolore veniam dolore non et commodo anim in amet aliqua ex laboris anim esse.</p>
+    </div>
+
+    <script>
+      (function iife() {
+        'use strict';
+
+        /**
+         * Hide long content.
+         *
+         * This script is inline, so that the attributes appear in the DOM
+         * before the CD Dropdown script runs during DOMContentLoaded. In doing
+         * so, we "dynamically" create the conditions for the dropdown on any
+         * length of content (which is unknown since it comes out of Drupal).
+         *
+         * If there are more elements than CONTENT_ELEMENT_LIMIT allows, we only
+         * display the first few, and add a toggling button to show the rest.
+         */
+        var content = document.getElementById('cd-dropdown-showmore-example');
+        var children = content.childNodes;
+        var count = 0;
+        for (var i = 0, l = children.length; i < l; i++) {
+          if (children[i].nodeType === 1) {
+            count++;
+          }
+        }
+
+        if (count) {
+          content.setAttribute('data-cd-toggable', 'Show full content');
+          content.setAttribute('data-cd-toggable-expanded', 'Hide full content');
+          content.setAttribute('data-cd-toggable-keep', '');
+          content.setAttribute('data-cd-insert-after', '');
+          content.setAttribute('data-cd-icon', 'arrow-down');
+          content.setAttribute('data-cd-component', 'cd-dropdown-showmore-example');
+          content.setAttribute('data-cd-replace', 'keep');
+        }
+      }());
+    </script>
+  </div>
+
+  <aside class="cd-layout__sidebar cd-layout__sidebar--wide">
+    <h2>Revealing hidden content</h2>
+    <p>You can use the CD Dropdown to reveal truncated content. See the script in the HTML which detects the content as it gets output, and preps the DOM for when CD Dropdown executes.</p>
+    <p>Look in the CD Dropdown README for the <code>data-cd-insert-after</code> attribute.</p>
+  </aside>
+</div>

--- a/components/cd/cd-resets/cd-typography.css
+++ b/components/cd/cd-resets/cd-typography.css
@@ -241,3 +241,13 @@ img {
   font-weight: 700;
   line-height: 1.3;
 }
+
+/**
+ * Code blocks in sidebars
+ */
+.cd-layout__sidebar code {
+  white-space: nowrap;
+  background: rgba(0,0,0,.15);
+  border-radius: 3px;
+  padding: .1em .2em;
+}

--- a/components/cd/cd-resets/cd-typography.css
+++ b/components/cd/cd-resets/cd-typography.css
@@ -246,8 +246,8 @@ img {
  * Code blocks in sidebars
  */
 .cd-layout__sidebar code {
-  white-space: nowrap;
-  background: rgba(0,0,0,.15);
-  border-radius: 3px;
   padding: .1em .2em;
+  white-space: nowrap;
+  border-radius: 3px;
+  background: rgba(0,0,0,.15);
 }

--- a/templates/layout/page--demo.html.twig
+++ b/templates/layout/page--demo.html.twig
@@ -126,6 +126,7 @@
           <li><a href="#cd-banner">Caption</a></li>
           <li><a href="#cd-card">Card</a></li>
           <li><a href="#cd-date">Date</a></li>
+          <li><a href="#cd-dropdown">Dropdown</a></li>
           <li><a href="#cd-event">Event</a></li>
           <li><a href="#cd-figure-list">Figure list</a></li>
           <li><a href="#cd-filter">Filter</a></li>
@@ -313,6 +314,11 @@
           {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
 
         {% include '@cd-components/cd-figure-list/cd-figure-list.html.twig' %}
+
+        <h3 class="cd-styleguide"><a id="cd-dropdown">cd-dropdown</a>
+          {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>
+
+        {% include '@cd-components/cd-dropdown/cd-dropdown.html.twig' %}
 
         <h3 class="cd-styleguide"><a id="cd-article">cd-article</a>
           {% include '@cd-components/cd-back-to-toc/cd-back-to-toc.html.twig' %}</h3>


### PR DESCRIPTION
# CD-489

Follow-up to #420 

## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
CD Dropdown entry for Demo page, plus changes to README. I looked at the example URL from RW in #420 and tried to mostly replicate that functionality.

## Steps to reproduce the problem or Steps to test

  1. Visit the demo page and click "Dropdown" in the ToC
  2. Try the button out. 
  3.

## Impact
No impact.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
