### PR TITLE
[CD-419] Add paragraphs-related theme suggestions

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -560,6 +560,11 @@ function common_design_preprocess_html(&$vars) {
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
+ *
+ * - page--demo.html.twig
+ * - page--401.html.twig
+ * - page--403.html.twig
+ * - page--404.html.twig
  */
 function common_design_theme_suggestions_page_alter(array &$suggestions, array $variables, $hook) {
   $current_uri = \Drupal::request()->getRequestUri();
@@ -568,7 +573,7 @@ function common_design_theme_suggestions_page_alter(array &$suggestions, array $
     $suggestions[] = $hook . '__demo';
   }
 
-  // Error page template suggestions.
+  // Error page template suggestions.: 401, 403, 404, etc
   if (!is_null(Drupal::requestStack()->getCurrentRequest()->attributes->get('exception'))) {
     $status_code = Drupal::requestStack()->getCurrentRequest()->attributes->get('exception')->getStatusCode();
     $suggestions[] = 'page__' . (string) $status_code;

--- a/common_design.theme
+++ b/common_design.theme
@@ -349,6 +349,25 @@ function common_design_theme_suggestions_form_element_alter(array &$suggestions,
 }
 
 /**
+ * Implements hook_theme_suggestions_paragraph_alter().
+ *
+ * - paragraph--PARENT-ENTITY--PARAGRAPH.html.twig
+ * - paragraph--PARENT-ENTITY--PARENT-FIELD--PARAGRAPH.html.twig
+ */
+function common_design_theme_suggestions_paragraph_alter(array &$suggestions, array $variables) {
+  $paragraph = $variables['elements']['#paragraph'];
+  $parent_entity = $paragraph->getParentEntity();
+  $parent_field_name = $paragraph->parent_field_name->value;
+
+  if ($parent_entity) {
+    $suggestions[] = 'paragraph__' . $parent_entity->bundle() . '__' . $paragraph->bundle();
+  }
+  if ($parent_entity && $parent_field_name) {
+    $suggestions[] = 'paragraph__' . $parent_entity->bundle() . '__' . $parent_field_name . '__' . $paragraph->bundle();
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function common_design_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Adds Paragraphs-related theme suggestions in the following format:

```sh
# Parent entity, e.g. Paragraphs rendered inside a Node versus a Group
# - paragraph--node--cta.html.twig
paragraph--PARENT-ENTITY--PARAGRAPH.html.twig

# Parent entity + parent field, e.g. rendering inside Main Content vs Sidebar
# - paragraph--node--field-paragraphs--cta.html.twig
# - paragraph--node--field-sidebar--cta.html.twig
paragraph--PARENT-ENTITY--PARENT-FIELD--PARAGRAPH.html.twig
```

## Steps to reproduce the problem or Steps to test

  1. Create a template in an existing installation with all the various entities and fields configured.
  2. Rebuild cache
  3. See if the template picks up automatically

## Impact
No impact. This is a new theme suggestion and if you created the same one in your subtheme, the end result is the same.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
