### PR TITLE
CD-504 Logo image suspected of redundant alt attribute

### DIFF
--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -5,6 +5,6 @@
  */
 #}
 <a href="{{ path('<front>') }}" title="{{ 'Front page'|t }}" rel="home" class="cd-site-logo">
-  <img src="{{ site_logo }}" alt="{{ site_name }}" aria-hidden="true">
+  <img src="{{ site_logo }}" alt="{{ site_name }} {{ 'logo'|t }}" aria-hidden="true">
   <span class="visually-hidden">{{ site_name }}</span>
 </a>

--- a/translations/ar-common-design.po
+++ b/translations/ar-common-design.po
@@ -54,3 +54,6 @@ msgstr "خدمات مكتب تنسيق الشؤون الإنسانية"
 
 msgid "Creative Commons BY 4.0"
 msgstr "Creative Commons BY 4.0"
+
+msgid "logo"
+msgstr ""

--- a/translations/es-common-design.po
+++ b/translations/es-common-design.po
@@ -49,3 +49,6 @@ msgstr "Servicios de OCHA"
 
 msgid "Creative Commons BY 4.0"
 msgstr "Creative Commons BY 4.0"
+
+msgid "logo"
+msgstr ""

--- a/translations/fr-common-design.po
+++ b/translations/fr-common-design.po
@@ -49,3 +49,6 @@ msgstr "Services OCHA"
 
 msgid "Creative Commons BY 4.0"
 msgstr "Creative Commons BY 4.0"
+
+msgid "logo"
+msgstr ""


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)

## Description
Check1st scans flag this as an "medium" severity accessibility issue, as "Image suspected of redundant alt attribute".
https://docs.wcag.online/criteria/h2/
I made the change on UNOCHA sub theme and can confirm it resolves the issue.

## Steps to reproduce the problem or Steps to test

  1. Look at the existing markup for the logo on https://web.brand.unocha.org/
  2. Notice the anchor title (actually a child span) and the img alt value match
  3. Check out the branch and notice the img alt value also includes the word "logo"

## Impact
This will remove the issue from the scans, thus decreasing the noise. And according to WGAG resolves an issue with "Critical " user impact.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
