### PR TITLE
CD-498 Remove ol list-style rule

### DIFF
--- a/components/cd-typography/cd-typography.html
+++ b/components/cd-typography/cd-typography.html
@@ -53,7 +53,13 @@
 
         <ol>
           <li>Example point one</li>
-          <li>Example point two</li>
+          <li>Example point two with nested
+            <ol>
+              <li>Example point two one</li>
+              <li>Example point two two</li>
+              <li>Example point two three</li>
+            </ol>
+          </li>
           <li>Example point three</li>
         </ol>
 

--- a/components/cd-typography/cd-typography.html.twig
+++ b/components/cd-typography/cd-typography.html.twig
@@ -54,7 +54,13 @@
 
   <ol>
     <li>Example point one</li>
-    <li>Example point two</li>
+    <li>Example point two with nested
+      <ol>
+        <li>Example point two one</li>
+        <li>Example point two two</li>
+        <li>Example point two three</li>
+      </ol>
+    </li>
     <li>Example point three</li>
   </ol>
 

--- a/components/cd/cd-resets/cd-typography.css
+++ b/components/cd/cd-resets/cd-typography.css
@@ -63,10 +63,6 @@ a:focus {
   color: var(--brand-primary);
 }
 
-ol {
-  list-style: decimal;
-}
-
 ol,
 dl {
   margin-bottom: 1rem;


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)

## Description
As described CD-498 this removes the rule to set the ol list style to decimal.

## Steps to reproduce the problem or Steps to test

  1. Check out this branch
  2. Visit /demo#cd-typography and look for the nested ordered list element
  3. Notice it uses numbers for all levels
  4. In the inspector, add `type="i"` to the nested ol tag See types: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#attributes
  5. Notice the nested ol's items are using roman numerals.

![Selection_028](https://github.com/UN-OCHA/common_design/assets/1835923/3c3ec896-403f-4f88-8b93-2521ba8d8e32)


## Impact
No negative repercussions expected. When ordered lists are added via the WYSIWYG and they have a type, the type will apply.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
