### PR TITLE
CD-500 Focus styles for main navigation

### DIFF
--- a/components/cd/cd-header/cd-language-switcher.css
+++ b/components/cd/cd-header/cd-language-switcher.css
@@ -18,10 +18,6 @@
   line-height: var(--cd-global-header-height);
 }
 
-.cd-language-switcher__btn:focus {
-  outline: var(--cd-outline-size) solid var(--brand-primary--light);
-}
-
 @media (min-width: 768px) {
   .cd-language-switcher__btn {
     padding-inline: 1.5rem;

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -254,7 +254,6 @@ ul[data-cd-hidden=true] > ul {
 
   .menu-item--collapsed .cd-nav-level-1__btn.is-active::before,
   .menu-item--expanded .cd-nav-level-1__btn.is-active::before {
-    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 
@@ -266,7 +265,6 @@ ul[data-cd-hidden=true] > ul {
     height: 48px;
     margin-inline-start: -15px;
     content: "";
-    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 
@@ -305,7 +303,6 @@ ul[data-cd-hidden=true] > ul {
 
   .cd-nav > .menu > .menu-item.menu-item--active-trail a::before,
   .cd-nav > .menu > .menu-item.menu-item--active-trail button::before {
-    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -265,6 +265,7 @@ ul[data-cd-hidden=true] > ul {
     height: 48px;
     margin-inline-start: -15px;
     content: "";
+    opacity: 0.6;
     background: var(--brand-highlight);
   }
 
@@ -281,7 +282,7 @@ ul[data-cd-hidden=true] > ul {
    */
   .cd-nav > ul ul > li.menu-item--active-trail a::before,
   .cd-nav > ul ul > li.menu-item--active-trail button::before {
-    opacity: 0.6;
+    opacity: 1;
   }
 }
 

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -347,6 +347,11 @@ ul[data-cd-hidden=true] > ul {
     background: var(--brand-highlight);
   }
 
+  .cd-nav > .menu > .menu-item:not(.menu-item--active-trail) > a:focus-visible::before,
+  .cd-nav > .menu > .menu-item:not(.menu-item--active-trail) button:focus-visible::before {
+    background: transparent;
+  }
+
   .cd-nav > .menu > .menu-item svg {
     flex: 1 0 auto;
   }

--- a/components/cd/cd-header/cd-nav.css
+++ b/components/cd/cd-header/cd-nav.css
@@ -135,6 +135,14 @@ ul[data-cd-hidden=true] > ul {
   background: var(--brand-grey);
 }
 
+.cd-nav a:focus-visible,
+.cd-nav button:focus-visible {
+  color: var(--cd-black);
+  outline: var(--cd-outline-size) solid var(--brand-primary--light);
+  outline-offset: calc(0px - var(--cd-outline-size));
+  background: transparent;
+}
+
 /**
  * First level
  */
@@ -246,7 +254,7 @@ ul[data-cd-hidden=true] > ul {
 
   .menu-item--collapsed .cd-nav-level-1__btn.is-active::before,
   .menu-item--expanded .cd-nav-level-1__btn.is-active::before {
-    opacity: 0.2;
+    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 
@@ -258,7 +266,7 @@ ul[data-cd-hidden=true] > ul {
     height: 48px;
     margin-inline-start: -15px;
     content: "";
-    opacity: 0.2;
+    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 
@@ -297,7 +305,7 @@ ul[data-cd-hidden=true] > ul {
 
   .cd-nav > .menu > .menu-item.menu-item--active-trail a::before,
   .cd-nav > .menu > .menu-item.menu-item--active-trail button::before {
-    opacity: 0.2;
+    /* opacity: 0.2; */
     background: var(--brand-highlight);
   }
 


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)

## Description
Increases the opacity of the active item underline for better visibility, uses consistent focus-visible styles so all items in header have the same style when tabbing with the keyboard.

## Steps to reproduce the problem or Steps to test
  1. Check out this branch and compare with https://web.brand.unocha.org
  2. The Active trail and Active item should be preserved but the opacity increased for better visibility, also on mobile
  3. The Main Menu keyboard tabbing should have a blue outline like the other elements, but the click focus should remain as before (we are distinguishing between focus and focus-visible now)

## Impact
Update the base theme with the latest release when this PR is merged and included.
This will correct a recent regression so if no overrides have been made in the sub theme, no work should be needed. If there are overrides in place to correct the opacity, these can be removed in favour of the changes in the base theme.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
