### PR TITLE
fix: remove duplicate announcement element from CD Social links

### DIFF
--- a/components/cd-social-links/cd-social-links.html.twig
+++ b/components/cd-social-links/cd-social-links.html.twig
@@ -5,7 +5,6 @@
 {% set shareUrl = 'https://example.com/#share-url' %}
 
 <footer class="cd-social-links">
-  <div role="status" class="cd-social-links__announce"></div>
   <div class="cd-social-links__wrapper">
     <span class="cd-social-links__label">{{ 'Share'|t }}</span>
     <ul class="cd-social-links__list" role="list">


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
While reviewing the Social Links I noticed the demo has two divs for announcements. One is totally unused and I probably left it there while developing the code and forgot about it. Its classname is totally absent from our codebase.

## Steps to reproduce the problem or Steps to test

  1. Load demo and click the 🔗  Social Link icon. If the message still pops up then it is fine.
  2.
  3.

## Impact
No impact. This is for CD Demo page only.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
