### PR TITLE
chore(release): 9.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.2.2](https://github.com/UN-OCHA/common_design/compare/v9.2.1...v9.2.2) (2023-10-26)
+
+### Bug Fixes
+
+* Focus styles for main navigation #441 CD-500
+* Twitter icon updated for CD Social Links #438 CD-502
+* remove duplicate announcement element from CD Social links #442
+* **ci:** run JS linter on base-theme PRs #437 CD-507
+* **ci:** run tests on sub-theme during PRs #440 CD-508
+
 
 ## [9.2.1](https://github.com/UN-OCHA/common_design/compare/v9.2.0...v9.2.1) (2023-10-11)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-design",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "common-design",
-      "version": "9.2.1",
+      "version": "9.2.2",
       "license": "GPL-2.0",
       "devDependencies": {
         "@xmldom/xmldom": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "OCHA Common Design base theme for Drupal 9+",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",


### PR DESCRIPTION
## [9.2.2](https://github.com/UN-OCHA/common_design/compare/v9.2.1...v9.2.2) (2023-10-26)

### Bug Fixes

* Focus styles for main navigation #441 CD-500
* Twitter icon updated for CD Social Links #438 CD-502
* remove duplicate announcement element from CD Social links #442
* **ci:** run JS linter on base-theme PRs #437 CD-507
* **ci:** run tests on sub-theme during PRs #440 CD-508
