### PR TITLE
fix: load primary font in a non-blocking manner

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -522,8 +522,13 @@ function common_design_preprocess_html(&$vars) {
   ];
   $vars['page']['#attached']['html_head'][] = [$js_detection, 'js-detection'];
 
-  // Construct a <link>s for Roboto: two that preconnect to Google Fonts, for a
+  // Construct <link>s for Roboto: two that preconnect to Google Fonts, for a
   // nominal performance improvement, and the link to the CSS file itself.
+  //
+  // To load the font in a totally non-blocking manner, we are using the media
+  // attribute to specify print until the fonts load, then we remove it with JS.
+  // There is no <noscript> in place, so the fonts won't load on non-JS browsers
+  // by design.
   //
   // To edit the font selection, visit the following URL:
   //
@@ -540,6 +545,8 @@ function common_design_preprocess_html(&$vars) {
   $roboto_default = [
     'rel' => 'stylesheet',
     'href' => 'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;0,900;1,400;1,700&display=swap',
+    'media' => 'print',
+    'onload' => 'this.onload=null;this.removeAttribute(`media`);',
   ];
 
 


### PR DESCRIPTION
Refs: CD-514

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Adds the `media="print"` attribute to the primary Google Fonts entry to load them in a non-blocking manner. The attribute gets stripped when JS is enabled and the file has loaded. Non-JS browsers will fail to load this font file entirely.

I didn't touch the special fonts in our libraries definitions because the Arabic and Chinese fonts are more necessary to render text properly, so applying this JS-dependent optimization felt like a bad move. Happy to discuss if people disagree.

## Steps to reproduce the problem or Steps to test

  1. View source and see if the markup comes down the pipe with `media="print" onload="..."`
  2. Inspect the same `<link>` element to see if the DOM got modified to remove `media="print"`

## Impact
No impact. We already used `display:swap` on our fonts so the behavior is identical.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.

