### PR TITLE
CD-527 Remove CSS custom property for mobile logo as it is no longer in use

### DIFF
--- a/css/brand.css
+++ b/css/brand.css
@@ -141,7 +141,6 @@
    * Specify the logo paths/dimensions here. The URL is relative to
    * common_design/components/cd/cd-header/cd-logo.css
    */
-  --brand-logo-mobile-url: url("../../../img/logos/ocha-logo-blue.svg");
   --brand-logo-mobile-width: 52px;
   --brand-logo-desktop-width: 186px;
 


### PR DESCRIPTION
Refs: CD-527

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Remove CSS custom property for mobile logo as it is no longer in use.
It was reverted as part of https://github.com/UN-OCHA/common_design/pull/406 but the variable remains

## Steps to reproduce the problem or Steps to test

  1. When the CSS variable is present, it appears in the aggregated CSS

## Impact
None except to remove reference to this in the aggregated CSS

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
