### PR TITLE
OPS-9885 Change directory for select_a11y css after SDC reshuffle

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -46,12 +46,12 @@ libraries-override:
   select_a11y/select_a11y_facets.widget:
     css:
       theme:
-        css/style.css: components/cd-select-a11y/cd-select-a11y.css
+        css/style.css: libraries/cd-select-a11y/cd-select-a11y.css
 
   select_a11y/select_a11y.widget:
     css:
       theme:
-        css/style.css: components/cd-select-a11y/cd-select-a11y.css
+        css/style.css: libraries/cd-select-a11y/cd-select-a11y.css
 
 # CD components
 # Requires Components module

--- a/common_design_subtheme/.stylelintignore
+++ b/common_design_subtheme/.stylelintignore
@@ -1,1 +1,1 @@
-components/cd-select-a11y/*.css
+libraries/cd-select-a11y/*.css

--- a/common_design_subtheme/README.md
+++ b/common_design_subtheme/README.md
@@ -38,7 +38,7 @@ Adjust `--brand-logo-desktop-width` to match your logo's dimensions
 
   - `--brand-logo-mobile-width`
 
-You must also update the `url()` within `components/cd/cd-header/cd-logo.css`
+You must also update the `url()` within `libraries/cd/cd-header/cd-logo.css`
 
 
 ### Customise the favicon and homescreen icons

--- a/common_design_subtheme/css/brand.css
+++ b/common_design_subtheme/css/brand.css
@@ -15,7 +15,7 @@
    *
    * Specify the logo dimensions here. To change the image URL, edit this file:
    *
-   * @see common_design_subtheme/components/cd/cd-header/cd-logo.css
+   * @see common_design_subtheme/libraries/cd/cd-header/cd-logo.css
    */
   --brand-logo-mobile-width: 52px;
   --brand-logo-desktop-width: 186px;

--- a/css/brand.css
+++ b/css/brand.css
@@ -139,7 +139,7 @@
    * Site logos
    *
    * Specify the logo paths/dimensions here. The URL is relative to
-   * common_design/components/cd/cd-header/cd-logo.css
+   * common_design/libraries/cd/cd-header/cd-logo.css
    */
   --brand-logo-mobile-width: 52px;
   --brand-logo-desktop-width: 186px;

--- a/libraries/cd-author/cd-author.html.twig
+++ b/libraries/cd-author/cd-author.html.twig
@@ -7,7 +7,7 @@
 
 <footer class="cd-author [ cd-bumper ]">
   <div class="cd-author__image cd-author__image--rounded">
-    <img src="/themes/contrib/common_design/components/cd-byline/mark-lowcock.jpg" alt="Mark Lowcock">
+    <img src="/themes/contrib/common_design/libraries/cd-byline/mark-lowcock.jpg" alt="Mark Lowcock">
   </div>
 
   <div class="cd-author__content">

--- a/libraries/cd-search--inline/cd-search--inline.css
+++ b/libraries/cd-search--inline/cd-search--inline.css
@@ -1,5 +1,5 @@
 /**
  * CD Search: inline
  *
- * @see components/cd/cd-header/cd-search--inline.css
+ * @see libraries/cd/cd-header/cd-search--inline.css
  */

--- a/libraries/cd-search/cd-search.css
+++ b/libraries/cd-search/cd-search.css
@@ -1,5 +1,5 @@
 /**
  * CD Search
  *
- * @see components/cd/cd-header/cd-search.css
+ * @see libraries/cd/cd-header/cd-search.css
  */

--- a/libraries/cd/cd-header/cd-language-switcher.css
+++ b/libraries/cd/cd-header/cd-language-switcher.css
@@ -78,7 +78,7 @@
  * rules to a smaller breakpoint should your website need it. Do NOT adjust
  * here, only in the sub-theme.
  *
- * @see common_design_subtheme/components/cd-language-switcher/cd-language-switcher.css
+ * @see common_design_subtheme/libraries/cd-language-switcher/cd-language-switcher.css
  */
 @media (min-width: 1024px) {
   /**


### PR DESCRIPTION
Refs: OPS-9885

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
After implementing SDC, there was one library `select_a11y` that was still trying to get its CSS from `components` folder.

## Steps to reproduce the problem or Steps to test

  1. Compare https://web.brand.unocha.org/facets (which is not picking up the styles) with https://feature.commondesign-unocha-org.ahconu.org/facets (which is an old deploy and still picking up styles from components directory due to older base theme version)
  2. With the changes in this PR, the stylesheet paths are correct and the result should look like the current Feature site, once the base theme version is updated.

## Impact
This is a bug fix so anywhere Facets are used with select_a11y widget should display correctly after updating the base theme with this fix in place.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have made changes to the sub theme to reflect those in the base theme
