### PR TITLE
chore(release): 9.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [9.3.2](https://github.com/UN-OCHA/common_design/compare/v9.3.1...v9.3.2) (2024-02-12)
+
+### Bug Fixes
+
+* set flex grow on last child to 0 to prevent full width when wrapping ([6ab5675](https://github.com/UN-OCHA/common_design/commit/6ab5675381e428a42647ed4bf103a3327ae70d3f))
+
+
 ## [9.3.1](https://github.com/UN-OCHA/common_design/compare/v9.3.0...v9.3.1) (2024-01-17)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-design",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "common-design",
-      "version": "9.3.1",
+      "version": "9.3.2",
       "license": "GPL-2.0",
       "devDependencies": {
         "@xmldom/xmldom": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "OCHA Common Design base theme for Drupal 9+",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",


### PR DESCRIPTION
## [9.3.2](https://github.com/UN-OCHA/common_design/compare/v9.3.1...v9.3.2) (2024-02-12)

### Bug Fixes

* set flex grow on last child to 0 to prevent full width when wrapping ([6ab5675](https://github.com/UN-OCHA/common_design/commit/6ab5675381e428a42647ed4bf103a3327ae70d3f))
