### PR TITLE
fix: retain OCHA Services border on mobile

### DIFF
--- a/libraries/cd/cd-footer/cd-ocha.css
+++ b/libraries/cd/cd-footer/cd-ocha.css
@@ -2,22 +2,28 @@
  * Common Design: OCHA Services
  */
 .cd-ocha-services {
-  @media screen and (min-width: 768px) {
-    position: relative;
-    margin-block-end: 3rem;
-    padding-block-end: 1rem;
+  position: relative;
+  margin-block-end: 3rem;
+  padding-block-end: 1rem;
 
-    /* Add a horizontal separator once layout expands */
+  /* Add a horizontal separator once layout expands */
+  &::before {
+    position: absolute;
+    bottom: 0;
+    left: 10%;
+    display: block;
+    width: 80%;
+    height: 1px;
+    content: '';
+    opacity: 0.6;
+    background: var(--cd-white);
+
+  }
+
+  @media screen and (min-width: 768px) {
     &::before {
-      position: absolute;
-      bottom: 0;
       left: 0;
-      display: block;
       width: 100%;
-      height: 1px;
-      content: '';
-      opacity: 0.6;
-      background: var(--cd-white);
     }
   }
 }


### PR DESCRIPTION
Refs: CD-537


## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Design feedback from Javi.

## Steps to reproduce the problem or Steps to test

  1. Load branch
  2. Border should now exist below OCHA Services even on mobile.

## Impact
CSS only. No impact to existing sub-themes.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [x] I have made changes to the sub theme to reflect those in the base theme
