### PR TITLE
chore(release): 9.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [9.3.4](https://github.com/UN-OCHA/common_design/compare/v9.3.3...v9.3.4) (2024-02-26)
+
+### Bug Fixes
+
+* retain OCHA Services border on mobile ([02f1f3b](https://github.com/UN-OCHA/common_design/commit/02f1f3b7632e2d0becaeba0e526cd92110037bf7))
+* update example markup for fonts in README ([d59c9e1](https://github.com/UN-OCHA/common_design/commit/d59c9e1a17620b20602e3b6e5c6bfba8ff9fb876))
+
+
 ### [9.3.3](https://github.com/UN-OCHA/common_design/compare/v9.3.2...v9.3.3) (2024-02-22)
 
 ### Bug Fixes

--- a/common_design_subtheme/package-lock.json
+++ b/common_design_subtheme/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design-subtheme",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/common_design_subtheme/package.json
+++ b/common_design_subtheme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design-subtheme",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "OCHA Common Design sub theme for Drupal 9+",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common-design",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "common-design",
-      "version": "9.3.3",
+      "version": "9.3.4",
       "license": "GPL-2.0",
       "devDependencies": {
         "@xmldom/xmldom": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-design",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "OCHA Common Design base theme for Drupal 9+",
   "repository": "git@github.com:UN-OCHA/common_design.git",
   "author": "UN OCHA",


### PR DESCRIPTION
### [9.3.4](https://github.com/UN-OCHA/common_design/compare/v9.3.3...v9.3.4) (2024-02-26)

### Bug Fixes

* retain OCHA Services border on mobile ([02f1f3b](https://github.com/UN-OCHA/common_design/commit/02f1f3b7632e2d0becaeba0e526cd92110037bf7))
* update example markup for fonts in README ([d59c9e1](https://github.com/UN-OCHA/common_design/commit/d59c9e1a17620b20602e3b6e5c6bfba8ff9fb876))
