### PR TITLE
feat: Non blocking font

### DIFF
--- a/common_design.theme
+++ b/common_design.theme
@@ -543,12 +543,10 @@ function common_design_preprocess_html(&$vars) {
     'crossorigin' => TRUE,
   ];
   $roboto_default = [
-    'rel' => 'stylesheet',
+    'rel' => 'preload',
     'href' => 'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;0,900;1,400;1,700&display=swap',
-    'media' => 'print',
-    'onload' => 'this.onload=null;this.removeAttribute(`media`);',
+    'as' => 'style',
   ];
-
 
   // Add <link>s to HTML response.
   $vars['page']['#attached']['html_head_link'][] = [


### PR DESCRIPTION
Refs: #RWR-416, #CD-514

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Load google font in non blocking way

## Description

Load google font in non blocking way

## Steps to reproduce the problem or Steps to test

  1. Open page
  2. Run lighthouse
  3. *Eliminate render-blocking resources* should be empty

## Impact

Faster loading

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
