### PR TITLE
docs: provide correct preload markup in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Here are the technical details relating to the theme itself:
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&amp;display=swap" onload="this.onload=null;this.setAttribute(`rel`, `stylesheet`);" />
+<link rel="preload" href="https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,300%3B0,400%3B0,500%3B0,700%3B0,900%3B1,400%3B1,700&amp;display=swap" as="style" onload="this.onload=null;this.setAttribute(`rel`, `stylesheet`);" />
 ```
 
 - Additional fonts for advanced typography and other languages which don't use Latin character sets are available as [Drupal Libraries][drupal-libraries]. The list is defined in `common_design.libraries.yml`. For performance reasons, we do not include these by default. If your website must support character sets that are not included in the base-theme, refer to the sub-theme's Libraries file `common_design_subtheme.libraries.yml` to see a commented-out example helping you create your own Drupal Library.


### PR DESCRIPTION
Refs: CD-514, HID-2413


## Types of changes
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
I noticed this while upgrading HID. Preload sample markup was missing the `as` attribute.


## Steps to reproduce the problem or Steps to test
Docs only.

## Impact
Docs only, no impact to any site.

## PR Checklist
- [x] I have followed the Conventional Commits guidelines.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
