### PR TITLE
fix(style): pixel push for mandate logo

### DIFF
--- a/libraries/cd/cd-footer/cd-footer-mandate.css
+++ b/libraries/cd/cd-footer/cd-footer-mandate.css
@@ -13,11 +13,13 @@
 }
 
 .cd-mandate__logo {
+  position: relative;
+  top: -3px;
   display: block;
   width: 149px;
   height: 37px;
-  margin-inline: auto;
   margin-block-end: 1rem;
+  margin-inline: auto;
 }
 
 .cd-mandate__text {


### PR DESCRIPTION
While comparing some Strattic CD upgrades this logo was noticeably displaced compared to older versions of the CD. This makes it look more balanced.

Refs: CD-540

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
CSS nudging.

## Impact
CSS only, no impact.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
