### PR TITLE
fix(style): OCHA Services separator should inherit color

### DIFF
--- a/libraries/cd/cd-footer/cd-ocha.css
+++ b/libraries/cd/cd-footer/cd-ocha.css
@@ -16,7 +16,7 @@
     height: 1px;
     content: '';
     opacity: 0.6;
-    background: var(--cd-white);
+    background: currentColor;
 
   }
 


### PR DESCRIPTION
In case the footer color is so light that a different text color is needed, this rule will mean the separator always matches text color.

Refs: CD-547

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
We had a "hardcoded" CSS Var for OCHA Services separator, but now it uses `currentColor` to make it more override-friendly.

## Impact
CSS only. No impact.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
