### PR TITLE
[CD-554] default styles for field_group details/summary elements

### DIFF
--- a/libraries/cd-form/cd-form.css
+++ b/libraries/cd-form/cd-form.css
@@ -188,3 +188,40 @@ form .form-type-checkbox > .cd-form__description {
 form .fieldset-wrapper > .form-type-checkbox + .form-type-checkbox {
   margin-top: 1rem;
 }
+
+/**
+ * Enhancements to widgets from field_group module
+ */
+
+form .field-group-details {
+  margin-block-start: 1rem;
+  padding-inline: 1rem;
+  border-radius: 5px;
+  background: var(--brand-grey);
+}
+
+form .field-group-details[open] {
+  padding-block: 1rem;
+}
+
+/* <summary> needs to cancel padding on <details> when open */
+form .field-group-details[open] summary {
+  margin-block-start: -1rem;
+}
+
+/* normalize.css removes built-in browser affordance for <summary> so we are
+resetting its display */
+form .field-group-details summary {
+  display: list-item;
+  cursor: pointer;
+  border-radius: 5px;
+  margin-inline: -1rem; /* cancel padding on <details> */
+  padding-block: .25rem;
+  padding-inline: 1rem;
+  font-weight: 700;
+}
+
+form .field-group-details summary:focus-visible {
+  outline: 3px solid var(--cd-black);
+}
+


### PR DESCRIPTION
# CD-554

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
When collapsible `<details>` /`<summary>` elements are present, they didn't look clickable. Now they do, and have a background color to show how far they extend. 

## Steps to reproduce the problem or Steps to test

  1. Load a form that uses the `field_group` module (AI Summarization site has one)
  2. Interact with the widget via mouse or keyboard.

## Impact
CSS only. No impact.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
