### PR TITLE
chore: style status messages for 10.3

### DIFF
--- a/common_design.info.yml
+++ b/common_design.info.yml
@@ -36,6 +36,8 @@ regions:
 libraries-extend:
   core/drupal.dropbutton:
     - common_design/cd-dropbutton
+  core/drupal.message:
+    - common_design/messages
 
 libraries-override:
   core/modernizr:

--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -8,6 +8,15 @@ global-styling:
   dependencies:
     - common_design/cd-core
 
+# Style status messages when they come via bigpipe.
+# @see https://www.drupal.org/project/drupal/issues/3456176
+messages:
+  css:
+    component:
+      components/cd-alert/cd-alert.css: {}
+  js:
+    js/messages.js: {}
+
 # Roboto Condensed and Slab.
 # @see https://brand.unocha.org/d/xEPytAUjC3sH/visual-identity#/basics/fonts/advanced-users
 fonts-advanced:

--- a/js/messages.js
+++ b/js/messages.js
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * Message template overrides.
+ */
+
+((Drupal) => {
+  /**
+   * Overrides message theme function.
+   *
+   * @param {object} message
+   *   The message object.
+   * @param {string} message.text
+   *   The message text.
+   * @param {object} options
+   *   The message context.
+   * @param {string} options.type
+   *   The message type.
+   * @param {string} options.id
+   *   ID of the message, for reference.
+   *
+   * @return {HTMLElement}
+   *   A DOM Node.
+   */
+  Drupal.theme.message = ({ text }, { type, id }) => {
+    const messagesTypes = Drupal.Message.getMessageTypeLabels();
+    const messageWrapper = document.createElement('div');
+
+    messageWrapper.setAttribute('class', `messages messages--${type} cd-alert cd-alert--${type}`);
+    messageWrapper.setAttribute(
+      'role',
+      type === 'error' || type === 'warning' ? 'alert' : 'status',
+    );
+    var icon_type = 'about', role='status';
+    switch (type) {
+      case 'error':
+        icon_type = 'error';
+        role = 'alert';
+        break;
+      case 'warning':
+        icon_type = 'alert';
+        break;
+      case 'status':
+        icon_type = 'selected';
+    }
+    messageWrapper.setAttribute('data-drupal-message-id', id);
+    messageWrapper.setAttribute('data-drupal-message-type', type);
+
+    messageWrapper.innerHTML = `
+    <div role="${role}" aria-label="${type}">
+      <svg class="cd-icon cd-icon--${icon_type}" aria-hidden="true" focusable="false" width="24" height="24">
+        <use xlink:href="#cd-icon--${icon_type}"></use>
+      </svg>
+      <div class="cd-alert__container cd-max-width">
+        <div class="cd-alert__title">
+          <h2 class="visually-hidden">${messagesTypes[type]}</h2>
+        </div>
+        <div class="cd-alert__message [ cd-flow ]">
+          ${text}
+        </div>
+      </div>
+    </div>
+  `;
+
+    return messageWrapper;
+  };
+})(Drupal);

--- a/js/messages.js
+++ b/js/messages.js
@@ -4,6 +4,8 @@
  */
 
 ((Drupal) => {
+  'use strict';
+
   /**
    * Overrides message theme function.
    *
@@ -21,34 +23,33 @@
    * @return {HTMLElement}
    *   A DOM Node.
    */
-  Drupal.theme.message = ({ text }, { type, id }) => {
+
+  Drupal.theme.message = ({text}, {type, id}) => {
     const messagesTypes = Drupal.Message.getMessageTypeLabels();
     const messageWrapper = document.createElement('div');
 
     messageWrapper.setAttribute('class', `messages messages--${type} cd-alert cd-alert--${type}`);
-    messageWrapper.setAttribute(
-      'role',
-      type === 'error' || type === 'warning' ? 'alert' : 'status',
-    );
-    var icon_type = 'about', role='status';
+    messageWrapper.setAttribute('role', type === 'error' || type === 'warning' ? 'alert' : 'status',);
+    var iconType = 'about';
+    var role='status';
     switch (type) {
       case 'error':
-        icon_type = 'error';
+        iconType = 'error';
         role = 'alert';
         break;
       case 'warning':
-        icon_type = 'alert';
+        iconType = 'alert';
         break;
       case 'status':
-        icon_type = 'selected';
+        iconType = 'selected';
     }
     messageWrapper.setAttribute('data-drupal-message-id', id);
     messageWrapper.setAttribute('data-drupal-message-type', type);
 
     messageWrapper.innerHTML = `
     <div role="${role}" aria-label="${type}">
-      <svg class="cd-icon cd-icon--${icon_type}" aria-hidden="true" focusable="false" width="24" height="24">
-        <use xlink:href="#cd-icon--${icon_type}"></use>
+      <svg class="cd-icon cd-icon--${iconType}" aria-hidden="true" focusable="false" width="24" height="24">
+        <use xlink:href="#cd-icon--${iconType}"></use>
       </svg>
       <div class="cd-alert__container cd-max-width">
         <div class="cd-alert__title">

--- a/js/messages.js
+++ b/js/messages.js
@@ -29,9 +29,9 @@
     const messageWrapper = document.createElement('div');
 
     messageWrapper.setAttribute('class', `messages messages--${type} cd-alert cd-alert--${type}`);
-    messageWrapper.setAttribute('role', type === 'error' || type === 'warning' ? 'alert' : 'status',);
+    messageWrapper.setAttribute('role', type === 'error' || type === 'warning' ? 'alert' : 'status');
     var iconType = 'about';
-    var role='status';
+    var role = 'status';
     switch (type) {
       case 'error':
         iconType = 'error';


### PR DESCRIPTION
Refs: OPS-10532

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
Discovered during testing feedback from GMS - a change in bigpipe means now theme-hints for status messages don't work as they did. As suggested in https://www.drupal.org/project/drupal/issues/3456176, we now should theme them in a js template rather than through twig. Leaving the twig template for status messages that aren't handled by js.


## Steps to reproduce the problem or Steps to test

  1. Trigger a status message on a non-admin page.

## Impact
How does the proposed change impact existing implementations? What action is needed to accommodate these changes?

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
