### PR TITLE
chore: use updated path for component libraries

### DIFF
--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -13,7 +13,7 @@ global-styling:
 messages:
   css:
     component:
-      components/cd-alert/cd-alert.css: {}
+      libraries/cd-alert/cd-alert.css: {}
   js:
     js/messages.js: {}
 


### PR DESCRIPTION
Refs: OPS-10532

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
-  Improvement (non-breaking change which iterates on an existing feature)
- :heavy_check_mark: Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Security update (dependency updates, or to fix a vulnerability)

## Description
I tested the last change in a site using an old version of CD - components should now be in the `libraries/` directory. This fixes that.

## Steps to reproduce the problem or Steps to test

  ![image](https://github.com/user-attachments/assets/e9cc20e2-ec95-4698-a84a-cc3d45178ef6)

## Impact
Bug fix from last release.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [ x] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
