### PR TITLE
chore: avoid lazy loading for print

### DIFF
--- a/common_design.libraries.yml
+++ b/common_design.libraries.yml
@@ -118,6 +118,8 @@ cd-other:
       libraries/cd/cd-other/cd-skip-link.css: {}
     theme:
       libraries/cd/cd-other/cd-print.css: {}
+  js:
+    js/cd-print.js: {}
 
 cd-core:
   dependencies:

--- a/js/cd-print.js
+++ b/js/cd-print.js
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * Print helper.
+ */
+
+((Drupal) => {
+  'use strict';
+
+  Drupal.behaviors.cdPrint = {
+
+    // Remove lazy loading before printing.
+    window.addEventListener("beforeprint", (event) => {
+      $('img').each(() => {
+        $(this).removeAttr('loading'));
+      }
+    }
+
+  };
+})(Drupal);


### PR DESCRIPTION
Refs: OPS-11125

<!-- Delete any parts of this template not applicable to your Pull Request. -->

## Types of changes
<!-- Put `:heavy_check_mark:` next to all the types of changes that apply: -->
- :heavy_check_mark: Improvement (non-breaking change which iterates on an existing feature)

## Description
Remove lazy loading before printing.

## Steps to reproduce the problem or Steps to test

https://humanitarian.atlassian.net/browse/OPS-11125

## Impact
This adds a snippet of js to all pages, to avoid printing lazy-loading images. This may be too much.

## PR Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [ x ] I have followed the Conventional Commits guidelines.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have made changes to the sub theme to reflect those in the base theme
